### PR TITLE
Add DHT method resolve support

### DIFF
--- a/dids/bearerdid.go
+++ b/dids/bearerdid.go
@@ -83,6 +83,6 @@ type PortableDID struct {
 // VerificationMethodKeyPair is a public/private keypair associated to a
 // BearerDID's verification method. Used in PortableDID
 type VerificationMethodKeyPair struct {
-	PublicKeyJWK  jwk.JWK `json:"publicKeyJwk"`
-	PrivateKeyJWK jwk.JWK `json:"privateKeyJwk"`
+	PublicKeyJWK  *jwk.JWK `json:"publicKeyJwk"`
+	PrivateKeyJWK jwk.JWK  `json:"privateKeyJwk"`
 }

--- a/dids/bearerdid_test.go
+++ b/dids/bearerdid_test.go
@@ -21,8 +21,8 @@ func Test_ToKeys(t *testing.T) {
 
 	vm := portableDID.VerificationMethod[0]
 
-	assert.NotEqual[jwk.JWK](t, *vm.PublicKeyJWK, jwk.JWK{}, "expected publicKeyJwk to not be empty")
-	assert.NotEqual[jwk.JWK](t, vm.PrivateKeyJWK, jwk.JWK{}, "expected privateKeyJWK to not be empty")
+	assert.NotEqual(t, *vm.PublicKeyJWK, jwk.JWK{}, "expected publicKeyJwk to not be empty")
+	assert.NotEqual(t, vm.PrivateKeyJWK, jwk.JWK{}, "expected privateKeyJWK to not be empty")
 }
 
 func TestBearerDIDFromKeys(t *testing.T) {

--- a/dids/bearerdid_test.go
+++ b/dids/bearerdid_test.go
@@ -21,7 +21,7 @@ func Test_ToKeys(t *testing.T) {
 
 	vm := portableDID.VerificationMethod[0]
 
-	assert.NotEqual[jwk.JWK](t, vm.PublicKeyJWK, jwk.JWK{}, "expected publicKeyJwk to not be empty")
+	assert.NotEqual[jwk.JWK](t, *vm.PublicKeyJWK, jwk.JWK{}, "expected publicKeyJwk to not be empty")
 	assert.NotEqual[jwk.JWK](t, vm.PrivateKeyJWK, jwk.JWK{}, "expected privateKeyJWK to not be empty")
 }
 

--- a/dids/did_dht.go
+++ b/dids/did_dht.go
@@ -1,0 +1,310 @@
+package dids
+
+import (
+	"encoding/base64"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"golang.org/x/net/dns/dnsmessage"
+
+	"github.com/tbd54566975/web5-go/crypto/dsa"
+	"github.com/tv42/zbase32"
+)
+
+var txtEntityNames = map[string]struct{}{
+	"vm":   {},
+	"auth": {},
+	"asm":  {},
+	"agm":  {},
+	"inv":  {},
+	"del":  {},
+}
+
+var relationshipDNStoDID = map[string]string{
+	"auth": "authentication",
+	"asm":  "assertionMethod",
+	"agm":  "keyAgreement",
+	"inv":  "capabilityInvocation",
+	"del":  "capabilityDelegation",
+}
+
+var keyTypes = map[string]string{
+	"0": dsa.AlgorithmIDED25519,
+	"1": dsa.AlgorithmIDSECP256K1,
+	"2": dsa.AlgorithmIDSECP256K1,
+}
+
+// dhtDIDRecord is used to structure the DNS representation of a DID
+type dhtDIDRecord struct {
+	rootRecord string
+	records    map[string]string
+}
+
+func (rec *dhtDIDRecord) DIDDocument(didURI string) *Document {
+	relationshipMap := parseVerificationRelationships(rec.rootRecord)
+
+	// Now we have a did in a dns record. yay
+	document := &Document{
+		ID: didURI,
+	}
+
+	// Now create the did document
+	for name, data := range rec.records {
+
+		switch {
+		case strings.HasPrefix(name, "_k"):
+			{
+				vMethod, err := UnmarshalVerificationMethod(data)
+				if err != nil {
+					// TODO handle error
+				}
+
+				// extracting kN from _kN._did
+				entryId := strings.Split(name, ".")[0][1:]
+				relationships, ok := relationshipMap[entryId]
+
+				if !ok {
+					// no relationships
+					continue
+				}
+
+				opts := []string{}
+				for _, r := range relationships {
+					if o, ok := relationshipDNStoDID[r]; ok {
+						opts = append(opts, o)
+					}
+				}
+
+				document.AddVerificationMethod(
+					*vMethod,
+					Purposes(opts...),
+				)
+			}
+		case strings.HasPrefix(name, "_s"):
+			s := UnmarshalService(data)
+			document.AddService(s)
+		case strings.HasPrefix(name, "_cnt"):
+			// TODO add controller https://did-dht.com/#controller
+			// optional field
+			// comma-separated list of controller DID identifiers
+			document.Controller = strings.Split(data, ",")
+		case strings.HasPrefix(name, "_aka"):
+			// TODO add aka https://did-dht.com/#also-known-as
+			document.AlsoKnownAs = strings.Split(data, ",")
+		default:
+		}
+	}
+
+	return document
+}
+
+func ResolveDIDDHT(uri, relay string, client *http.Client) (*Document, error) {
+	// 1. Parse URI and make sure it's a DHT method
+	// 2. Get the public key bytes / decode did.id from z-base-32
+	// 3. create the bep44 message - needs the zbase32 encoded publicKey / did.id
+	// 4. create the Pkarr url with the relay + did.id
+	// 5. fetch
+	// 6. bep44 message using (publicKey bytes - decoded zbase32 - ) etc.
+	// 7. fetch the dns packet using the bep44 message
+	// 8. decode the dns packet
+	// 9. create the did document
+
+	// 1. Parse URI and make sure it's a DHT method
+	did, err := Parse(uri)
+	if err != nil {
+		return nil, err
+	}
+
+	// 2. ensure did ID is zbase32
+	identifier, err := zbase32.DecodeString(did.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(identifier) <= 0 {
+		return nil, fmt.Errorf("no bytes decoded from zbase32 identifier %s", did.ID)
+	}
+
+	// 3. fetch bep44 encoded did document
+	res, err := client.Get(fmt.Sprintf("%s/%s", relay, did.ID))
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+
+	data, err := io.ReadAll(res.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	didRecord, err := parseDNSDID(data)
+	if err != nil {
+		return nil, err
+	}
+
+	return didRecord.DIDDocument(uri), nil
+}
+
+// parseDNSDID takes the bytes of the DNS representation of a DID and creates an internal representation
+// used to create a DID document
+func parseDNSDID(data []byte) (*dhtDIDRecord, error) {
+	var p dnsmessage.Parser
+	if _, err := p.Start(data); err != nil {
+		return nil, err
+	}
+
+	didRecord := dhtDIDRecord{
+		records: make(map[string]string),
+	}
+
+	// need to skip questions to move the index to the right place to read answers
+	if err := p.SkipAllQuestions(); err != nil {
+		return nil, err
+	}
+
+	for {
+		h, err := p.AnswerHeader()
+		if err == dnsmessage.ErrSectionDone {
+			break
+		}
+
+		if h.Type != dnsmessage.TypeTXT {
+			continue
+		}
+
+		value, err := p.TXTResource()
+		if err != nil {
+			// TODO check what kind of error and see if this should fail
+		}
+
+		name := h.Name.String()
+		fullTxtRecord := strings.Join(value.TXT, "")
+		if strings.HasPrefix(name, "_did") {
+			didRecord.rootRecord = fullTxtRecord
+			continue
+		}
+
+		if _, ok := didRecord.records[h.Name.String()]; !ok {
+
+		}
+		didRecord.records[h.Name.String()] = fullTxtRecord
+	}
+
+	return &didRecord, nil
+}
+
+// TODO on the diddhtrecord we should validate the minimum reqs for a valid did
+func parseVerificationRelationships(rootRecord string) map[string][]string {
+	rootRecordProps := parseTXTRecordData(rootRecord)
+
+	// reverse the map to get the relationships
+	relationshipMap := map[string][]string{}
+	for k, values := range rootRecordProps {
+		v := strings.Join(values, "")
+		rel, ok := relationshipMap[v]
+		if !ok {
+			rel = []string{}
+		}
+		rel = append(rel, k)
+		relationshipMap[v] = rel
+	}
+
+	return relationshipMap
+}
+
+func parseTXTRecordData(data string) map[string][]string {
+	result := map[string][]string{}
+	fields := strings.Split(data, ";")
+	for _, field := range fields {
+		kv := strings.Split(field, "=")
+		k, v := kv[0], strings.Split(kv[1], ",")
+		current, ok := result[k]
+		if ok {
+			v = append(current, v...)
+		}
+		result[k] = v
+	}
+
+	return result
+}
+
+func Create(did *Document) {
+
+}
+
+// UnmarshalVerificationMethod unpacks the TXT DNS resource encoded verification method
+func UnmarshalVerificationMethod(data string) (*VerificationMethod, error) {
+	propertyMap := parseTXTRecordData(data)
+
+	vm := &VerificationMethod{}
+	var key string
+	var algorithmID string
+	for property, v := range propertyMap {
+		switch property {
+		// According to https://did-dht.com/#verification-methods, this should not be a list
+		case "id":
+			vm.ID = strings.Join(v, "")
+		case "t": // Index of the key type https://did-dht.com/registry/index.html#key-type-index
+			algorithmID, _ = keyTypes[strings.Join(v, "")]
+		case "k": // unpadded base64URL representation of the public key
+			key = strings.Join(v, "")
+		case "c": // the controller is optional
+			vm.Controller = strings.Join(v, "")
+		}
+	}
+
+	if len(key) <= 0 || len(algorithmID) <= 0 {
+		return nil, fmt.Errorf("unable to parse public key")
+	}
+
+	// RawURLEncoding is the same as URLEncoding but omits padding.
+	// Decoding and reencoding to make sure there is no padding
+	keyBytes, err := base64.RawURLEncoding.DecodeString(key)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(keyBytes) <= 0 {
+		return nil, fmt.Errorf("empty key")
+	}
+
+	j, err := dsa.BytesToPublicKey(algorithmID, keyBytes)
+	if err != nil {
+		return nil, err
+	}
+	vm.PublicKeyJwk = &j
+
+	// validate all the parts exist
+	if len(vm.ID) <= 0 || vm.PublicKeyJwk == nil {
+		return nil, fmt.Errorf("malformed verification method representation")
+	}
+
+	return vm, nil
+}
+
+func UnmarshalService(data string) *Service {
+	propertyMap := parseTXTRecordData(data)
+
+	s := &Service{}
+	for property, v := range propertyMap {
+		switch property {
+		case "id":
+			s.ID = strings.Join(v, "")
+		case "t":
+			s.Type = strings.Join(v, "")
+		case "se":
+			validEndpoints := []string{}
+			for _, uri := range v {
+				if _, err := url.ParseRequestURI(uri); err != nil {
+					validEndpoints = append(validEndpoints, uri)
+				}
+			}
+			s.ServiceEndpoint = strings.Join(validEndpoints, ",")
+		}
+	}
+
+	return s
+}

--- a/dids/did_dht.go
+++ b/dids/did_dht.go
@@ -56,33 +56,31 @@ func (rec *dhtDIDRecord) DIDDocument(didURI string) *Document {
 
 		switch {
 		case strings.HasPrefix(name, "_k"):
-			{
-				vMethod, err := UnmarshalVerificationMethod(data)
-				if err != nil {
-					// TODO handle error
-				}
-
-				// extracting kN from _kN._did
-				entryId := strings.Split(name, ".")[0][1:]
-				relationships, ok := relationshipMap[entryId]
-
-				if !ok {
-					// no relationships
-					continue
-				}
-
-				opts := []string{}
-				for _, r := range relationships {
-					if o, ok := relationshipDNStoDID[r]; ok {
-						opts = append(opts, o)
-					}
-				}
-
-				document.AddVerificationMethod(
-					*vMethod,
-					Purposes(opts...),
-				)
+			vMethod, err := UnmarshalVerificationMethod(data)
+			if err != nil {
+				// TODO handle error
 			}
+
+			// extracting kN from _kN._did
+			entryId := strings.Split(name, ".")[0][1:]
+			relationships, ok := relationshipMap[entryId]
+
+			if !ok {
+				// no relationships
+				continue
+			}
+
+			opts := []string{}
+			for _, r := range relationships {
+				if o, ok := relationshipDNStoDID[r]; ok {
+					opts = append(opts, o)
+				}
+			}
+
+			document.AddVerificationMethod(
+				*vMethod,
+				Purposes(opts...),
+			)
 		case strings.HasPrefix(name, "_s"):
 			s := UnmarshalService(data)
 			document.AddService(s)
@@ -101,16 +99,8 @@ func (rec *dhtDIDRecord) DIDDocument(didURI string) *Document {
 	return document
 }
 
+// ResolveDIDDHT resolves a DID using the DHT method
 func ResolveDIDDHT(uri, relay string, client *http.Client) (ResolutionResult, error) {
-	// 1. Parse URI and make sure it's a DHT method
-	// 2. Get the public key bytes / decode did.id from z-base-32
-	// 3. create the bep44 message - needs the zbase32 encoded publicKey / did.id
-	// 4. create the Pkarr url with the relay + did.id
-	// 5. fetch
-	// 6. bep44 message using (publicKey bytes - decoded zbase32 - ) etc.
-	// 7. fetch the dns packet using the bep44 message
-	// 8. decode the dns packet
-	// 9. create the did document
 
 	// 1. Parse URI and make sure it's a DHT method
 	did, err := Parse(uri)
@@ -265,6 +255,8 @@ func UnmarshalVerificationMethod(data string) (*VerificationMethod, error) {
 			key = strings.Join(v, "")
 		case "c": // the controller is optional
 			vm.Controller = strings.Join(v, "")
+		default:
+			continue
 		}
 	}
 
@@ -315,6 +307,8 @@ func UnmarshalService(data string) *Service {
 				}
 			}
 			s.ServiceEndpoint = strings.Join(validEndpoints, ",")
+		default:
+			continue
 		}
 	}
 

--- a/dids/did_dht_test.go
+++ b/dids/did_dht_test.go
@@ -1,0 +1,129 @@
+package dids
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	"github.com/alecthomas/assert/v2"
+	"golang.org/x/net/dns/dnsmessage"
+)
+
+type bep44TXTResourceOpt func() dnsmessage.Resource
+
+func WithDNSRecord(name, body string) bep44TXTResourceOpt {
+	return func() dnsmessage.Resource {
+		return dnsmessage.Resource{
+			Header: dnsmessage.ResourceHeader{
+				Name: dnsmessage.MustNewName(name),
+				Type: dnsmessage.TypeTXT,
+				TTL:  7200,
+			},
+			Body: &dnsmessage.TXTResource{
+				TXT: []string{
+					body,
+				},
+			},
+		}
+	}
+}
+func makeDNSMessage(answersOpt ...bep44TXTResourceOpt) dnsmessage.Message {
+
+	answers := []dnsmessage.Resource{}
+	for _, a := range answersOpt {
+		answers = append(answers, a())
+	}
+
+	msg := dnsmessage.Message{
+		Header:  dnsmessage.Header{Response: true, Authoritative: true},
+		Answers: answers,
+	}
+
+	return msg
+}
+
+func TestDHTResolve(t *testing.T) {
+
+	tests := map[string]struct {
+		msg           dnsmessage.Message
+		expectedError error
+		assertResult  func(t *testing.T, d *Document)
+	}{
+		"basic did with key": {
+			msg: makeDNSMessage(
+				WithDNSRecord("_did.", "vm=k0;auth=k0;asm=k0;inv=k0;del=k0"),
+				WithDNSRecord("_k0._did.", "id=0;t=0;k=YCcHYL2sYNPDlKaALcEmll2HHyT968M4UWbr-9CFGWE"),
+			),
+			expectedError: nil,
+			assertResult: func(t *testing.T, d *Document) {
+				assert.False(t, d == nil, "Expected non nil document")
+				assert.NotZero[string](t, d.ID, "Expected DID Document ID to be initialized")
+				assert.NotZero[[]VerificationMethod](t, d.VerificationMethod, "Expected at least 1 verification method")
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			buf, err := test.msg.Pack()
+			assert.NoError(t, err)
+			// test setup
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				_, err := w.Write(buf)
+				assert.NoError(t, err)
+			}))
+			defer ts.Close()
+
+			document, err := ResolveDIDDHT("did:dht:cwxob5rbhhu3z9x3gfqy6cthqgm6ngrh4k8s615n7pw11czoq4fy", ts.URL, http.DefaultClient)
+
+			if test.expectedError != nil {
+				assert.Error(t, test.expectedError, err)
+				return
+			}
+
+			test.assertResult(t, document)
+		})
+
+	}
+}
+
+func Test_parseDNSDID(t *testing.T) {
+	tests := map[string]struct {
+		msg           dnsmessage.Message
+		expectedError error
+		assertResult  func(t *testing.T, d *dhtDIDRecord)
+	}{
+		"basic did with key": {
+			msg: makeDNSMessage(
+				WithDNSRecord("_did.", "vm=k0;auth=k0;asm=k0;inv=k0;del=k0"),
+				WithDNSRecord("_k0._did.", "id=0;t=0;k=YCcHYL2sYNPDlKaALcEmll2HHyT968M4UWbr-9CFGWE"),
+			),
+			expectedError: nil,
+			assertResult: func(t *testing.T, d *dhtDIDRecord) {
+				assert.False(t, d == nil)
+				expectedRecords := map[string]string{
+					"_k0._did.": "id=0;t=0;k=YCcHYL2sYNPDlKaALcEmll2HHyT968M4UWbr-9CFGWE",
+				}
+				assert.Equal(t, "vm=k0;auth=k0;asm=k0;inv=k0;del=k0", d.rootRecord)
+				assert.True(t, reflect.DeepEqual(expectedRecords, d.records))
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			buf, err := test.msg.Pack()
+			assert.NoError(t, err)
+
+			dhtDidRecord, err := parseDNSDID(buf)
+			if test.expectedError != nil {
+				assert.Error(t, test.expectedError, err)
+				return
+			}
+
+			assert.Equal(t, "vm=k0;auth=k0;asm=k0;inv=k0;del=k0", dhtDidRecord.rootRecord)
+
+		})
+	}
+}

--- a/dids/did_dht_test.go
+++ b/dids/did_dht_test.go
@@ -116,14 +116,14 @@ func TestDHTResolve(t *testing.T) {
 			}))
 			defer ts.Close()
 
-			document, err := ResolveDIDDHT(test.didURI, ts.URL, http.DefaultClient)
+			result, err := ResolveDIDDHT(test.didURI, ts.URL, http.DefaultClient)
 
 			if test.expectedError != nil {
 				assert.Error(t, test.expectedError, err)
 				return
 			}
 
-			test.assertResult(t, document)
+			test.assertResult(t, &result.Document)
 		})
 
 	}

--- a/dids/did_dht_test.go
+++ b/dids/did_dht_test.go
@@ -1,6 +1,9 @@
 package dids
 
 import (
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -44,13 +47,20 @@ func makeDNSMessage(answersOpt ...bep44TXTResourceOpt) dnsmessage.Message {
 }
 
 func TestDHTResolve(t *testing.T) {
+	// vector taken from https://github.com/TBD54566975/web5-js/blob/dids-new-crypto/packages/crypto/tests/fixtures/test-vectors/secp256k1/bytes-to-public-key.json
+	publicKeyHexSecp256k1 := "0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8"
+	pubKeyBytesSecp256k1, err := hex.DecodeString(publicKeyHexSecp256k1)
+	assert.NoError(t, err)
+	base64EncodedSecp256k := base64.RawURLEncoding.EncodeToString(pubKeyBytesSecp256k1)
 
 	tests := map[string]struct {
+		didURI        string
 		msg           dnsmessage.Message
 		expectedError error
 		assertResult  func(t *testing.T, d *Document)
 	}{
-		"basic did with key": {
+		"did with valid key and no service": {
+			didURI: "did:dht:cwxob5rbhhu3z9x3gfqy6cthqgm6ngrh4k8s615n7pw11czoq4fy",
 			msg: makeDNSMessage(
 				WithDNSRecord("_did.", "vm=k0;auth=k0;asm=k0;inv=k0;del=k0"),
 				WithDNSRecord("_k0._did.", "id=0;t=0;k=YCcHYL2sYNPDlKaALcEmll2HHyT968M4UWbr-9CFGWE"),
@@ -60,6 +70,37 @@ func TestDHTResolve(t *testing.T) {
 				assert.False(t, d == nil, "Expected non nil document")
 				assert.NotZero[string](t, d.ID, "Expected DID Document ID to be initialized")
 				assert.NotZero[[]VerificationMethod](t, d.VerificationMethod, "Expected at least 1 verification method")
+			},
+		},
+		"did with multiple valid keys and no service - out of order verification methods": {
+			didURI: "did:dht:cwxob5rbhhu3z9x3gfqy6cthqgm6ngrh4k8s615n7pw11czoq4fy",
+			msg: makeDNSMessage(
+				WithDNSRecord("_did.", "vm=k0,k1,k2;auth=k0;asm=k1;inv=k2;del=k0"),
+				WithDNSRecord("_k0._did.", "id=0;t=0;k=YCcHYL2sYNPDlKaALcEmll2HHyT968M4UWbr-9CFGWE"),
+				WithDNSRecord("_k2._did.", fmt.Sprintf("id=2;t=1;k=%s", base64EncodedSecp256k)),
+				WithDNSRecord("_k1._did.", fmt.Sprintf("id=1;t=2;k=%s", base64EncodedSecp256k)),
+			),
+			expectedError: nil,
+			assertResult: func(t *testing.T, d *Document) {
+				assert.False(t, d == nil, "Expected non nil document")
+				assert.NotZero[string](t, d.ID, "Expected DID Document ID to be initialized")
+				assert.Equal[int](t, 3, len(d.VerificationMethod), "Expected 3 verification methods")
+			},
+		},
+		"did with key controller and services": {
+			didURI: "did:dht:cwxob5rbhhu3z9x3gfqy6cthqgm6ngrh4k8s615n7pw11czoq4fy",
+			msg: makeDNSMessage(
+				WithDNSRecord("_did.", "vm=k0;auth=k0;asm=k0;inv=k0;del=k0;srv=s0,s1"),
+				WithDNSRecord("_k0._did.", "id=0;t=0;k=YCcHYL2sYNPDlKaALcEmll2HHyT968M4UWbr-9CFGWE"),
+				WithDNSRecord("_s0._did.", "id=domain;t=LinkedDomains;se=foo.com"),
+				WithDNSRecord("_s1._did.", "id=dwn;t=DecentralizedWebNode;se=https://dwn.tbddev.org/dwn5"),
+			),
+			expectedError: nil,
+			assertResult: func(t *testing.T, d *Document) {
+				assert.False(t, d == nil, "Expected non nil document")
+				assert.NotZero[string](t, d.ID, "Expected DID Document ID to be initialized")
+				assert.NotZero[[]VerificationMethod](t, d.VerificationMethod, "Expected at least 1 verification method")
+				assert.Equal[int](t, 2, len(d.Service), "Expected 2 services")
 			},
 		},
 	}
@@ -75,7 +116,7 @@ func TestDHTResolve(t *testing.T) {
 			}))
 			defer ts.Close()
 
-			document, err := ResolveDIDDHT("did:dht:cwxob5rbhhu3z9x3gfqy6cthqgm6ngrh4k8s615n7pw11czoq4fy", ts.URL, http.DefaultClient)
+			document, err := ResolveDIDDHT(test.didURI, ts.URL, http.DefaultClient)
 
 			if test.expectedError != nil {
 				assert.Error(t, test.expectedError, err)

--- a/dids/didjwk.go
+++ b/dids/didjwk.go
@@ -105,7 +105,7 @@ func ResolveDIDJWK(uri string) (ResolutionResult, error) {
 		ID:           uri + "#0",
 		Type:         "JsonWebKey2020",
 		Controller:   uri,
-		PublicKeyJwk: jwk,
+		PublicKeyJwk: &jwk,
 	}
 
 	doc.AddVerificationMethod(

--- a/dids/didjwk_test.go
+++ b/dids/didjwk_test.go
@@ -26,7 +26,7 @@ func TestResolveDIDJWK(t *testing.T) {
 
 	vm := result.Document.VerificationMethod[0]
 	assert.True(t, vm != VerificationMethod{}, "expected verification method to be non-empty")
-	assert.True(t, vm.PublicKeyJwk != (jwk.JWK{}), "expected publicKeyJwk to be non-empty")
+	assert.NotEqual[jwk.JWK](t, jwk.JWK{}, *vm.PublicKeyJwk, "expected publicKeyJwk to be non-empty")
 
 	assert.Equal(t, len(result.Document.Authentication), 1)
 	assert.Equal(t, len(result.Document.AssertionMethod), 1)

--- a/dids/document.go
+++ b/dids/document.go
@@ -36,7 +36,7 @@ type Document struct {
 	// Service expresses ways of communicating with the DID subject or associated entities.
 	// A service can be any type of service the DID subject wants to advertise.
 	// spec reference: https://www.w3.org/TR/did-core/#verification-methods
-	Service []Service `json:"service,omitempty"`
+	Service []*Service `json:"service,omitempty"`
 
 	// AssertionMethod is used to specify how the DID subject is expected to express claims,
 	// such as for the purposes of issuing a Verifiable Credential.
@@ -95,6 +95,10 @@ func (d *Document) AddVerificationMethod(method VerificationMethod, opts ...AddV
 			d.CapabilityInvocation = append(d.CapabilityInvocation, method.ID)
 		}
 	}
+}
+
+func (d *Document) AddService(service *Service) {
+	d.Service = append(d.Service, service)
 }
 
 // DocumentMetadata contains metadata about the DID Document
@@ -182,5 +186,5 @@ type VerificationMethod struct {
 	// a value that conforms to the rules in DID Syntax: https://www.w3.org/TR/did-core/#did-syntax
 	Controller string `json:"controller"`
 	// specification reference: https://www.w3.org/TR/did-core/#dfn-publickeyjwk
-	PublicKeyJwk jwk.JWK `json:"publicKeyJwk,omitempty"`
+	PublicKeyJwk *jwk.JWK `json:"publicKeyJwk,omitempty"`
 }

--- a/go.mod
+++ b/go.mod
@@ -2,9 +2,12 @@ module github.com/tbd54566975/web5-go
 
 go 1.21.6
 
-require github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0
-
-require github.com/alecthomas/assert/v2 v2.5.0
+require (
+	github.com/alecthomas/assert/v2 v2.5.0
+	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0
+	github.com/tv42/zbase32 v0.0.0-20220222190657-f76a9fc892fa
+	golang.org/x/net v0.20.0
+)
 
 require (
 	github.com/alecthomas/repr v0.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -8,3 +8,7 @@ github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0 h1:8UrgZ3GkP4i/CLijOJx79Yu+etly
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0/go.mod h1:v57UDF4pDQJcEfFUCRop3lJL149eHGSe9Jvczhzjo/0=
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
 github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
+github.com/tv42/zbase32 v0.0.0-20220222190657-f76a9fc892fa h1:2EwhXkNkeMjX9iFYGWLPQLPhw9O58BhnYgtYKeqybcY=
+github.com/tv42/zbase32 v0.0.0-20220222190657-f76a9fc892fa/go.mod h1:is48sjgBanWcA5CQrPBu9Y5yABY/T2awj/zI65bq704=
+golang.org/x/net v0.20.0 h1:aCL9BSgETF1k+blQaYUBx9hJ9LOGP3gAVemcZlf1Kpo=
+golang.org/x/net v0.20.0/go.mod h1:z8BVo6PvndSri0LbOE3hAn0apkU+1YvI6E70E9jsnvY=

--- a/jwk/jwk.go
+++ b/jwk/jwk.go
@@ -12,6 +12,7 @@ import (
 // spec allows for that are not represented here at the moment. This is because we
 // only need a subset of the spec for our purposes.
 type JWK struct {
+	ALG string `json:"alg,omitempty"`
 	KTY string `json:"kty,omitempty"`
 	CRV string `json:"crv,omitempty"`
 	D   string `json:"d,omitempty"`

--- a/jws/jws.go
+++ b/jws/jws.go
@@ -132,7 +132,7 @@ func Sign(payload JWSPayload, did dids.BearerDID, opts ...SignOpts) (string, err
 		verificationMethodID = verificationMethod.ID
 	}
 
-	jwa, err := dsa.GetJWA(verificationMethod.PublicKeyJwk)
+	jwa, err := dsa.GetJWA(*verificationMethod.PublicKeyJwk)
 	if err != nil {
 		return "", fmt.Errorf("failed to determine alg: %s", err.Error())
 	}
@@ -229,7 +229,7 @@ func Verify(compactJWS string) (bool, error) {
 		return false, fmt.Errorf("no verification method found that matches kid: %s", verificationMethodID)
 	}
 
-	verified, err := dsa.Verify(toVerifyBytes, signature, verificationMethod.PublicKeyJwk)
+	verified, err := dsa.Verify(toVerifyBytes, signature, *verificationMethod.PublicKeyJwk)
 	if err != nil {
 		return false, fmt.Errorf("failed to verify signature: %s", err.Error())
 	}


### PR DESCRIPTION
# Summary
Implements the resolve functionality of the DHT DID method [spec](https://did-dht.com/#abstract).

# Usage
```go
package main

import (
          ...
	"github.com/tbd545669675/web5-go/dids", 
)

func main() {
	result, err := dids.ResolveDIDDHT("did:dht:cwxob5rbhhu3z9x3gfqy6cthqgm6ngrh4k8s615n7pw11czoq4fy", "https://diddht.tbddev.org",  http.DefaultClient)

}
```