### PR TITLE
Public Key Bytes -> JWK

### DIFF
--- a/crypto/dsa/dsa.go
+++ b/crypto/dsa/dsa.go
@@ -71,3 +71,14 @@ func GetJWA(jwk jwk.JWK) (string, error) {
 		return "", fmt.Errorf("unsupported key type: %s", jwk.KTY)
 	}
 }
+
+// BytesToPublicKey converts the given bytes to a public key based on the algorithm specified by algorithmID.
+func BytesToPublicKey(algorithmID string, input []byte) (jwk.JWK, error) {
+	if ecdsa.SupportsAlgorithmID(algorithmID) {
+		return ecdsa.BytesToPublicKey(algorithmID, input)
+	} else if eddsa.SupportsAlgorithmID(algorithmID) {
+		return eddsa.BytesToPublicKey(algorithmID, input)
+	} else {
+		return jwk.JWK{}, fmt.Errorf("unsupported algorithm: %s", algorithmID)
+	}
+}

--- a/crypto/dsa/dsa_test.go
+++ b/crypto/dsa/dsa_test.go
@@ -115,3 +115,13 @@ func TestVerifyED25519(t *testing.T) {
 
 	assert.True(t, legit, "failed to verify signature")
 }
+
+func TestBytesToPublicKey_BadAlgorithm(t *testing.T) {
+	_, err := dsa.BytesToPublicKey("yolocrypto", []byte{0x00, 0x01, 0x02, 0x03})
+	assert.Error(t, err)
+}
+
+func TestBytesToPublicKey_BadBytes(t *testing.T) {
+	_, err := dsa.BytesToPublicKey(dsa.AlgorithmIDSECP256K1, []byte{0x00, 0x01, 0x02, 0x03})
+	assert.Error(t, err)
+}

--- a/crypto/dsa/dsa_test.go
+++ b/crypto/dsa/dsa_test.go
@@ -1,6 +1,7 @@
 package dsa_test
 
 import (
+	"encoding/hex"
 	"testing"
 
 	"github.com/alecthomas/assert/v2"
@@ -124,4 +125,19 @@ func TestBytesToPublicKey_BadAlgorithm(t *testing.T) {
 func TestBytesToPublicKey_BadBytes(t *testing.T) {
 	_, err := dsa.BytesToPublicKey(dsa.AlgorithmIDSECP256K1, []byte{0x00, 0x01, 0x02, 0x03})
 	assert.Error(t, err)
+}
+
+func TestBytesToPublicKey_SECP256K1(t *testing.T) {
+	// vector taken from		// vector taken from https://github.com/TBD54566975/web5-js/blob/dids-new-crypto/packages/crypto/tests/fixtures/test-vectors/secp256k1/bytes-to-public-key.json
+	publicKeyHex := "0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8"
+	pubKeyBytes, err := hex.DecodeString(publicKeyHex)
+	assert.NoError(t, err)
+
+	jwk, err := dsa.BytesToPublicKey(dsa.AlgorithmIDSECP256K1, pubKeyBytes)
+	assert.NoError(t, err)
+
+	assert.Equal(t, jwk.CRV, ecdsa.SECP256K1JWACurve)
+	assert.Equal(t, jwk.KTY, ecdsa.KeyType)
+	assert.Equal(t, jwk.X, "eb5mfvncu6xVoGKVzocLBwKb_NstzijZWfKBWxb4F5g")
+	assert.Equal(t, jwk.Y, "SDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj_sQ1Lg")
 }

--- a/crypto/dsa/ecdsa/ecdsa.go
+++ b/crypto/dsa/ecdsa/ecdsa.go
@@ -63,6 +63,15 @@ func GetJWA(jwk jwk.JWK) (string, error) {
 	}
 }
 
+func BytesToPublicKey(algorithmID string, input []byte) (jwk.JWK, error) {
+	switch algorithmID {
+	case SECP256K1AlgorithmID:
+		return SECP256K1BytesToPublicKey(input)
+	default:
+		return jwk.JWK{}, fmt.Errorf("unsupported algorithm: %s", algorithmID)
+	}
+}
+
 func SupportsAlgorithmID(id string) bool {
 	return algorithmIDs[id]
 }

--- a/crypto/dsa/ecdsa/secp256k1.go
+++ b/crypto/dsa/ecdsa/secp256k1.go
@@ -86,3 +86,17 @@ func SECP256K1Verify(payload []byte, signature []byte, publicKey jwk.JWK) (bool,
 
 	return legit, nil
 }
+
+func SECP256K1BytesToPublicKey(input []byte) (jwk.JWK, error) {
+	pubKey, err := _secp256k1.ParsePubKey(input)
+	if err != nil {
+		return jwk.JWK{}, fmt.Errorf("failed to parse public key: %w", err)
+	}
+
+	return jwk.JWK{
+		KTY: KeyType,
+		CRV: SECP256K1JWACurve,
+		X:   base64.RawURLEncoding.EncodeToString(pubKey.X().Bytes()),
+		Y:   base64.RawURLEncoding.EncodeToString(pubKey.Y().Bytes()),
+	}, nil
+}

--- a/crypto/dsa/ecdsa/secp256k1.go
+++ b/crypto/dsa/ecdsa/secp256k1.go
@@ -87,6 +87,7 @@ func SECP256K1Verify(payload []byte, signature []byte, publicKey jwk.JWK) (bool,
 	return legit, nil
 }
 
+// SECP256K1BytesToPublicKey converts a secp256k1 public key to a JWK. Supports both Compressed and Uncompressed public keys described in https://www.secg.org/sec1-v2.pdf section 2.3.3
 func SECP256K1BytesToPublicKey(input []byte) (jwk.JWK, error) {
 	pubKey, err := _secp256k1.ParsePubKey(input)
 	if err != nil {

--- a/crypto/dsa/ecdsa/secp256k1_test.go
+++ b/crypto/dsa/ecdsa/secp256k1_test.go
@@ -1,6 +1,7 @@
 package ecdsa_test
 
 import (
+	"encoding/hex"
 	"testing"
 
 	"github.com/alecthomas/assert/v2"
@@ -16,4 +17,24 @@ func TestSECP256K1GeneratePrivateKey(t *testing.T) {
 	assert.True(t, key.D != "", "privateJwk.D is empty")
 	assert.True(t, key.X != "", "privateJwk.X is empty")
 	assert.True(t, key.Y != "", "privateJwk.Y is empty")
+}
+
+func TestSECP256K1BytesToPublicKey_Bad(t *testing.T) {
+	_, err := ecdsa.SECP256K1BytesToPublicKey([]byte{0x00, 0x01, 0x02, 0x03})
+	assert.Error(t, err)
+}
+
+func TestSECP256K1BytesToPublicKey_Uncompressed(t *testing.T) {
+	// vector taken from https://github.com/TBD54566975/web5-js/blob/dids-new-crypto/packages/crypto/tests/fixtures/test-vectors/secp256k1/bytes-to-public-key.json
+	publicKeyHex := "0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8"
+	pubKeyBytes, err := hex.DecodeString(publicKeyHex)
+	assert.NoError(t, err)
+
+	jwk, err := ecdsa.SECP256K1BytesToPublicKey(pubKeyBytes)
+	assert.NoError(t, err)
+
+	assert.Equal(t, jwk.CRV, ecdsa.SECP256K1JWACurve)
+	assert.Equal(t, jwk.KTY, ecdsa.KeyType)
+	assert.Equal(t, jwk.X, "eb5mfvncu6xVoGKVzocLBwKb_NstzijZWfKBWxb4F5g")
+	assert.Equal(t, jwk.Y, "SDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj_sQ1Lg")
 }

--- a/crypto/dsa/eddsa/ed25519.go
+++ b/crypto/dsa/eddsa/ed25519.go
@@ -49,3 +49,17 @@ func ED25519Verify(payload []byte, signature []byte, publicKey jwk.JWK) (bool, e
 	legit := _ed25519.Verify(publicKeyBytes, payload, signature)
 	return legit, nil
 }
+
+func ED25519BytesToPublicKey(input []byte) (jwk.JWK, error) {
+	if len(input) != _ed25519.PublicKeySize {
+		return jwk.JWK{}, fmt.Errorf("invalid public key")
+	}
+
+	publicKey := jwk.JWK{
+		KTY: KeyType,
+		CRV: ED25519JWACurve,
+		X:   base64.RawURLEncoding.EncodeToString(input),
+	}
+
+	return publicKey, nil
+}

--- a/crypto/dsa/eddsa/ed25519.go
+++ b/crypto/dsa/eddsa/ed25519.go
@@ -55,11 +55,9 @@ func ED25519BytesToPublicKey(input []byte) (jwk.JWK, error) {
 		return jwk.JWK{}, fmt.Errorf("invalid public key")
 	}
 
-	publicKey := jwk.JWK{
+	return jwk.JWK{
 		KTY: KeyType,
 		CRV: ED25519JWACurve,
 		X:   base64.RawURLEncoding.EncodeToString(input),
-	}
-
-	return publicKey, nil
+	}, nil
 }

--- a/crypto/dsa/eddsa/ed25519_test.go
+++ b/crypto/dsa/eddsa/ed25519_test.go
@@ -1,0 +1,29 @@
+package eddsa_test
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/alecthomas/assert/v2"
+	"github.com/tbd54566975/web5-go/crypto/dsa/eddsa"
+)
+
+func TestED25519BytesToPublicKey_Bad(t *testing.T) {
+	publicKeyBytes := []byte{0x00, 0x01, 0x02, 0x03}
+	_, err := eddsa.ED25519BytesToPublicKey(publicKeyBytes)
+	assert.Error(t, err)
+}
+
+func TestED25519BytesToPublicKey_Good(t *testing.T) {
+	// vector taken from https://github.com/TBD54566975/web5-js/blob/dids-new-crypto/packages/crypto/tests/fixtures/test-vectors/ed25519/bytes-to-public-key.json
+	pubKeyHex := "7d4d0e7f6153a69b6242b522abbee685fda4420f8834b108c3bdae369ef549fa"
+	pubKeyBytes, err := hex.DecodeString(pubKeyHex)
+	assert.NoError(t, err)
+
+	jwk, err := eddsa.ED25519BytesToPublicKey(pubKeyBytes)
+	assert.NoError(t, err)
+
+	assert.Equal(t, jwk.KTY, eddsa.KeyType)
+	assert.Equal(t, jwk.CRV, eddsa.ED25519JWACurve)
+	assert.Equal(t, jwk.X, "fU0Of2FTpptiQrUiq77mhf2kQg-INLEIw72uNp71Sfo")
+}

--- a/crypto/dsa/eddsa/eddsa.go
+++ b/crypto/dsa/eddsa/eddsa.go
@@ -61,6 +61,15 @@ func GetJWA(jwk jwk.JWK) (string, error) {
 	return JWA, nil
 }
 
+func BytesToPublicKey(algorithmID string, input []byte) (jwk.JWK, error) {
+	switch algorithmID {
+	case ED25519AlgorithmID:
+		return ED25519BytesToPublicKey(input)
+	default:
+		return jwk.JWK{}, fmt.Errorf("unsupported algorithm: %s", algorithmID)
+	}
+}
+
 func SupportsAlgorithmID(id string) bool {
 	return algorithmIDs[id]
 }


### PR DESCRIPTION
# Summary
Implements Methods to convert public key bytes -> JWKs based on a specified algorithm ID. In support of https://github.com/TBD54566975/web5-go/pull/3#discussion_r1474913355. Includes minimal test coverage. full coverage to come when we consume test vectors [here](https://github.com/tbd54566975/web5-spec)

# Usage
```go
package main

import (
	"encoding/hex"
	"fmt"
	"log"

	"github.com/tbd545669675/web5-go/crypto/dsa"
)

func main() {
	// Example vector taken from: https://github.com/TBD54566975/web5-js/blob/dids-new-crypto/packages/crypto/tests/fixtures/test-vectors/secp256k1/bytes-to-public-key.json
	publicKeyHex := "0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8"
	pubKeyBytes, err := hex.DecodeString(publicKeyHex)
	if err != nil {
		log.Fatalf("Failed to decode public key hex: %v", err)
	}

	jwk, _ := dsa.BytesToPublicKey(dsa.AlgorithmIDSECP256K1, pubKeyBytes)
	fmt.Printf("JWK: %v\n", jwk)
}
```