### PR TITLE
Create common resolver interface

### DIFF
--- a/dids/did_dht.go
+++ b/dids/did_dht.go
@@ -37,6 +37,18 @@ var keyTypes = map[string]string{
 	"2": dsa.AlgorithmIDSECP256K1,
 }
 
+type DHTResolver struct {
+	relay  string
+	client *http.Client
+}
+
+func NewDHTResolver(relay string, client *http.Client) *DHTResolver {
+	return &DHTResolver{
+		relay:  relay,
+		client: client,
+	}
+}
+
 // dhtDIDRecord is used to structure the DNS representation of a DID
 type dhtDIDRecord struct {
 	rootRecord string
@@ -99,8 +111,8 @@ func (rec *dhtDIDRecord) DIDDocument(didURI string) *Document {
 	return document
 }
 
-// ResolveDIDDHT resolves a DID using the DHT method
-func ResolveDIDDHT(uri, relay string, client *http.Client) (ResolutionResult, error) {
+// Resolve resolves a DID using the DHT method
+func (r *DHTResolver) Resolve(uri string) (ResolutionResult, error) {
 
 	// 1. Parse URI and make sure it's a DHT method
 	did, err := Parse(uri)

--- a/dids/did_dht.go
+++ b/dids/did_dht.go
@@ -139,7 +139,7 @@ func (r *DHTResolver) Resolve(uri string) (ResolutionResult, error) {
 	}
 
 	// 3. fetch bep44 encoded did document
-	res, err := client.Get(fmt.Sprintf("%s/%s", relay, did.ID))
+	res, err := r.client.Get(fmt.Sprintf("%s/%s", r.relay, did.ID))
 	if err != nil {
 		// TODO log err
 		return ResolutionResultWithError("invalidDid"), ResolutionError{"invalidDid"}

--- a/dids/did_dht_test.go
+++ b/dids/did_dht_test.go
@@ -115,8 +115,8 @@ func TestDHTResolve(t *testing.T) {
 				assert.NoError(t, err)
 			}))
 			defer ts.Close()
-
-			result, err := ResolveDIDDHT(test.didURI, ts.URL, http.DefaultClient)
+			r := NewDHTResolver(ts.URL, http.DefaultClient)
+			result, err := r.Resolve(test.didURI)
 
 			assert.EqualError(t, err, test.expectedErrorMessage)
 

--- a/dids/didjwk.go
+++ b/dids/didjwk.go
@@ -74,8 +74,10 @@ func NewDIDJWK(opts ...NewDIDJWKOption) (BearerDID, error) {
 	return did, nil
 }
 
+type JWKResolver struct{}
+
 // Resolves the provided DID URI
-func ResolveDIDJWK(uri string) (ResolutionResult, error) {
+func (r JWKResolver) Resolve(uri string) (ResolutionResult, error) {
 	did, err := Parse(uri)
 	if err != nil {
 		return ResolutionResultWithError("invalidDid"), ResolutionError{"invalidDid"}

--- a/dids/didjwk_test.go
+++ b/dids/didjwk_test.go
@@ -20,7 +20,8 @@ func TestNewDIDJWK(t *testing.T) {
 }
 
 func TestResolveDIDJWK(t *testing.T) {
-	result, err := ResolveDIDJWK("did:jwk:eyJraWQiOiJ1cm46aWV0ZjpwYXJhbXM6b2F1dGg6andrLXRodW1icHJpbnQ6c2hhLTI1NjpGZk1iek9qTW1RNGVmVDZrdndUSUpqZWxUcWpsMHhqRUlXUTJxb2JzUk1NIiwia3R5IjoiT0tQIiwiY3J2IjoiRWQyNTUxOSIsImFsZyI6IkVkRFNBIiwieCI6IkFOUmpIX3p4Y0tCeHNqUlBVdHpSYnA3RlNWTEtKWFE5QVBYOU1QMWo3azQifQ")
+	resolver := &JWKResolver{}
+	result, err := resolver.Resolve("did:jwk:eyJraWQiOiJ1cm46aWV0ZjpwYXJhbXM6b2F1dGg6andrLXRodW1icHJpbnQ6c2hhLTI1NjpGZk1iek9qTW1RNGVmVDZrdndUSUpqZWxUcWpsMHhqRUlXUTJxb2JzUk1NIiwia3R5IjoiT0tQIiwiY3J2IjoiRWQyNTUxOSIsImFsZyI6IkVkRFNBIiwieCI6IkFOUmpIX3p4Y0tCeHNqUlBVdHpSYnA3RlNWTEtKWFE5QVBYOU1QMWo3azQifQ")
 	assert.NoError(t, err)
 	assert.Equal(t, len(result.Document.VerificationMethod), 1)
 

--- a/dids/resolver.go
+++ b/dids/resolver.go
@@ -8,7 +8,7 @@ import (
 // Resolve resolves the provided DID URI. This function is capable of resolving
 // the DID methods implemented in web5-go
 func Resolve(uri string) (ResolutionResult, error) {
-	return getDefaultResolver().resolve(uri)
+	return getDefaultResolver().Resolve(uri)
 }
 
 var instance *didResolver
@@ -35,7 +35,7 @@ type didResolver struct {
 	resolvers map[string]DIDResolver
 }
 
-func (r *didResolver) resolve(uri string) (ResolutionResult, error) {
+func (r *didResolver) Resolve(uri string) (ResolutionResult, error) {
 	did, err := Parse(uri)
 	if err != nil {
 		return ResolutionResultWithError("invalidDid"), ResolutionError{"invalidDid"}

--- a/dids/resolver.go
+++ b/dids/resolver.go
@@ -11,8 +11,6 @@ func Resolve(uri string) (ResolutionResult, error) {
 	return getDefaultResolver().resolve(uri)
 }
 
-type methodResolver func(did string) (ResolutionResult, error)
-
 var instance *didResolver
 var once sync.Once
 


### PR DESCRIPTION
# Summary

This introduces the idea of an interface for the resolver and both jwk and dht implement the `.Resolve(did string)` interface. It makes the calls to the underlying resolvers more clean and apart from adding new methods, the resolution part should just work with no additional changes.

The PR still keeps a default resolver implementation available. 

## Caveats

DHT needs a little more context to resolve (a relay and an http client). JWK does not. In the PR the JWKResolver is an empty struct that is set up mainly to be able to implement the pattern/interface and has no real benefit right now. 