### PR TITLE
public key JWK -> bytes

### DIFF
--- a/crypto/dsa/dsa.go
+++ b/crypto/dsa/dsa.go
@@ -82,3 +82,15 @@ func BytesToPublicKey(algorithmID string, input []byte) (jwk.JWK, error) {
 		return jwk.JWK{}, fmt.Errorf("unsupported algorithm: %s", algorithmID)
 	}
 }
+
+// PublicKeyToBytes converts the provided public key to bytes
+func PublicKeyToBytes(publicKey jwk.JWK) ([]byte, error) {
+	switch publicKey.KTY {
+	case ecdsa.KeyType:
+		return ecdsa.PublicKeyToBytes(publicKey)
+	case eddsa.KeyType:
+		return eddsa.PublicKeyToBytes(publicKey)
+	default:
+		return nil, fmt.Errorf("unsupported key type: %s", publicKey.KTY)
+	}
+}

--- a/crypto/dsa/dsa_test.go
+++ b/crypto/dsa/dsa_test.go
@@ -129,7 +129,7 @@ func TestBytesToPublicKey_BadBytes(t *testing.T) {
 }
 
 func TestBytesToPublicKey_SECP256K1(t *testing.T) {
-	// vector taken from // vector taken from https://github.com/TBD54566975/web5-js/blob/dids-new-crypto/packages/crypto/tests/fixtures/test-vectors/secp256k1/bytes-to-public-key.json
+	// vector taken from https://github.com/TBD54566975/web5-js/blob/dids-new-crypto/packages/crypto/tests/fixtures/test-vectors/secp256k1/bytes-to-public-key.json
 	publicKeyHex := "0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8"
 	pubKeyBytes, err := hex.DecodeString(publicKeyHex)
 	assert.NoError(t, err)

--- a/crypto/dsa/dsa_test.go
+++ b/crypto/dsa/dsa_test.go
@@ -147,21 +147,3 @@ func TestPublicKeyToBytes_UnsupportedKTY(t *testing.T) {
 	_, err := dsa.PublicKeyToBytes(jwk.JWK{KTY: "yolocrypto"})
 	assert.Error(t, err)
 }
-
-func TestPublicKeyToBytes_SECP256K1(t *testing.T) {
-	// vector taken from https://github.com/TBD54566975/web5-js/blob/dids-new-crypto/packages/crypto/tests/fixtures/test-vectors/secp256k1/bytes-to-public-key.json
-	jwk := jwk.JWK{
-		KTY: "EC",
-		CRV: ecdsa.SECP256K1JWACurve,
-		X:   "eb5mfvncu6xVoGKVzocLBwKb_NstzijZWfKBWxb4F5g",
-		Y:   "SDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj_sQ1Lg",
-	}
-
-	pubKeyBytes, err := dsa.PublicKeyToBytes(jwk)
-	assert.NoError(t, err)
-
-	pubKeyHex := hex.EncodeToString(pubKeyBytes)
-	expected := "0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8"
-
-	assert.Equal(t, pubKeyHex, expected)
-}

--- a/crypto/dsa/dsa_test.go
+++ b/crypto/dsa/dsa_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/tbd54566975/web5-go/crypto/dsa"
 	"github.com/tbd54566975/web5-go/crypto/dsa/ecdsa"
 	"github.com/tbd54566975/web5-go/crypto/dsa/eddsa"
+	"github.com/tbd54566975/web5-go/jwk"
 )
 
 func TestGeneratePrivateKeySECP256K1(t *testing.T) {
@@ -128,7 +129,7 @@ func TestBytesToPublicKey_BadBytes(t *testing.T) {
 }
 
 func TestBytesToPublicKey_SECP256K1(t *testing.T) {
-	// vector taken from		// vector taken from https://github.com/TBD54566975/web5-js/blob/dids-new-crypto/packages/crypto/tests/fixtures/test-vectors/secp256k1/bytes-to-public-key.json
+	// vector taken from // vector taken from https://github.com/TBD54566975/web5-js/blob/dids-new-crypto/packages/crypto/tests/fixtures/test-vectors/secp256k1/bytes-to-public-key.json
 	publicKeyHex := "0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8"
 	pubKeyBytes, err := hex.DecodeString(publicKeyHex)
 	assert.NoError(t, err)
@@ -140,4 +141,27 @@ func TestBytesToPublicKey_SECP256K1(t *testing.T) {
 	assert.Equal(t, jwk.KTY, ecdsa.KeyType)
 	assert.Equal(t, jwk.X, "eb5mfvncu6xVoGKVzocLBwKb_NstzijZWfKBWxb4F5g")
 	assert.Equal(t, jwk.Y, "SDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj_sQ1Lg")
+}
+
+func TestPublicKeyToBytes_UnsupportedKTY(t *testing.T) {
+	_, err := dsa.PublicKeyToBytes(jwk.JWK{KTY: "yolocrypto"})
+	assert.Error(t, err)
+}
+
+func TestPublicKeyToBytes_SECP256K1(t *testing.T) {
+	// vector taken from https://github.com/TBD54566975/web5-js/blob/dids-new-crypto/packages/crypto/tests/fixtures/test-vectors/secp256k1/bytes-to-public-key.json
+	jwk := jwk.JWK{
+		KTY: "EC",
+		CRV: ecdsa.SECP256K1JWACurve,
+		X:   "eb5mfvncu6xVoGKVzocLBwKb_NstzijZWfKBWxb4F5g",
+		Y:   "SDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj_sQ1Lg",
+	}
+
+	pubKeyBytes, err := dsa.PublicKeyToBytes(jwk)
+	assert.NoError(t, err)
+
+	pubKeyHex := hex.EncodeToString(pubKeyBytes)
+	expected := "0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8"
+
+	assert.Equal(t, pubKeyHex, expected)
 }

--- a/crypto/dsa/ecdsa/ecdsa.go
+++ b/crypto/dsa/ecdsa/ecdsa.go
@@ -72,6 +72,15 @@ func BytesToPublicKey(algorithmID string, input []byte) (jwk.JWK, error) {
 	}
 }
 
+func PublicKeyToBytes(publicKey jwk.JWK) ([]byte, error) {
+	switch publicKey.CRV {
+	case SECP256K1JWACurve:
+		return SECP256K1PublicKeyToBytes(publicKey)
+	default:
+		return nil, fmt.Errorf("unsupported curve: %s", publicKey.CRV)
+	}
+}
+
 func SupportsAlgorithmID(id string) bool {
 	return algorithmIDs[id]
 }

--- a/crypto/dsa/ecdsa/secp256k1.go
+++ b/crypto/dsa/ecdsa/secp256k1.go
@@ -134,6 +134,10 @@ func secp256k1PublicKeyToUncheckedBytes(publicKey jwk.JWK) ([]byte, error) {
 		return nil, fmt.Errorf("failed to decode y: %w", err)
 	}
 
+	// Prepend 0x04 to indicate an uncompressed public key format for secp256k1.
+	// This byte is a prefix that distinguishes uncompressed keys, which include both X and Y coordinates,
+	// from compressed keys which only include one coordinate and an indication of the other's parity.
+	// The secp256k1 standard requires this prefix for uncompressed keys to ensure proper interpretation.
 	keyBytes := []byte{0x04}
 	keyBytes = append(keyBytes, x...)
 	keyBytes = append(keyBytes, y...)

--- a/crypto/dsa/ecdsa/secp256k1.go
+++ b/crypto/dsa/ecdsa/secp256k1.go
@@ -59,12 +59,10 @@ func SECP256K1Verify(payload []byte, signature []byte, publicKey jwk.JWK) (bool,
 
 	hash := sha256.Sum256(payload)
 
-	x, _ := base64.RawURLEncoding.DecodeString(publicKey.X)
-	y, _ := base64.RawURLEncoding.DecodeString(publicKey.Y)
-
-	keyBytes := []byte{0x04}
-	keyBytes = append(keyBytes, x...)
-	keyBytes = append(keyBytes, y...)
+	keyBytes, err := secp256k1PublicKeyToUncheckedBytes(publicKey)
+	if err != nil {
+		return false, fmt.Errorf("failed to convert public key to bytes: %w", err)
+	}
 
 	key, err := _secp256k1.ParsePubKey(keyBytes)
 	if err != nil {
@@ -87,7 +85,9 @@ func SECP256K1Verify(payload []byte, signature []byte, publicKey jwk.JWK) (bool,
 	return legit, nil
 }
 
-// SECP256K1BytesToPublicKey converts a secp256k1 public key to a JWK. Supports both Compressed and Uncompressed public keys described in https://www.secg.org/sec1-v2.pdf section 2.3.3
+// SECP256K1BytesToPublicKey converts a secp256k1 public key to a JWK.
+// Supports both Compressed and Uncompressed public keys described in
+// https://www.secg.org/sec1-v2.pdf section 2.3.3
 func SECP256K1BytesToPublicKey(input []byte) (jwk.JWK, error) {
 	pubKey, err := _secp256k1.ParsePubKey(input)
 	if err != nil {
@@ -100,4 +100,43 @@ func SECP256K1BytesToPublicKey(input []byte) (jwk.JWK, error) {
 		X:   base64.RawURLEncoding.EncodeToString(pubKey.X().Bytes()),
 		Y:   base64.RawURLEncoding.EncodeToString(pubKey.Y().Bytes()),
 	}, nil
+}
+
+// SECP256K1PublicKeyToBytes converts a secp256k1 public key JWK to bytes.
+// Note: this function returns the uncompressed public key. compressed is not
+// yet supported
+func SECP256K1PublicKeyToBytes(publicKey jwk.JWK) ([]byte, error) {
+	uncheckedBytes, err := secp256k1PublicKeyToUncheckedBytes(publicKey)
+	if err != nil {
+		return nil, err
+	}
+
+	key, err := _secp256k1.ParsePubKey(uncheckedBytes)
+	if err != nil {
+		return nil, fmt.Errorf("invalid public key: %w", err)
+	}
+
+	return key.SerializeUncompressed(), nil
+}
+
+func secp256k1PublicKeyToUncheckedBytes(publicKey jwk.JWK) ([]byte, error) {
+	if publicKey.X == "" || publicKey.Y == "" {
+		return nil, fmt.Errorf("x and y must be set")
+	}
+
+	x, err := base64.RawURLEncoding.DecodeString(publicKey.X)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode x: %w", err)
+	}
+
+	y, err := base64.RawURLEncoding.DecodeString(publicKey.Y)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode y: %w", err)
+	}
+
+	keyBytes := []byte{0x04}
+	keyBytes = append(keyBytes, x...)
+	keyBytes = append(keyBytes, y...)
+
+	return keyBytes, nil
 }

--- a/crypto/dsa/ecdsa/secp256k1_test.go
+++ b/crypto/dsa/ecdsa/secp256k1_test.go
@@ -49,7 +49,7 @@ func TestSECP256K1PublicKeyToBytes(t *testing.T) {
 		Y:   "SDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj_sQ1Lg",
 	}
 
-	pubKeyBytes, err := ecdsa.PublicKeyToBytes(jwk)
+	pubKeyBytes, err := ecdsa.SECP256K1PublicKeyToBytes(jwk)
 	assert.NoError(t, err)
 
 	pubKeyHex := hex.EncodeToString(pubKeyBytes)
@@ -91,7 +91,7 @@ func TestSECP256K1PublicKeyToBytes_Bad(t *testing.T) {
 	}
 
 	for _, vec := range vectors {
-		pubKeyBytes, err := ecdsa.PublicKeyToBytes(vec)
+		pubKeyBytes, err := ecdsa.SECP256K1PublicKeyToBytes(vec)
 		assert.Error(t, err)
 		assert.Equal(t, pubKeyBytes, nil)
 	}

--- a/crypto/dsa/ecdsa/secp256k1_test.go
+++ b/crypto/dsa/ecdsa/secp256k1_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/alecthomas/assert/v2"
 	"github.com/tbd54566975/web5-go/crypto/dsa/ecdsa"
+	"github.com/tbd54566975/web5-go/jwk"
 )
 
 func TestSECP256K1GeneratePrivateKey(t *testing.T) {
@@ -37,4 +38,61 @@ func TestSECP256K1BytesToPublicKey_Uncompressed(t *testing.T) {
 	assert.Equal(t, jwk.KTY, ecdsa.KeyType)
 	assert.Equal(t, jwk.X, "eb5mfvncu6xVoGKVzocLBwKb_NstzijZWfKBWxb4F5g")
 	assert.Equal(t, jwk.Y, "SDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj_sQ1Lg")
+}
+
+func TestSECP256K1PublicKeyToBytes(t *testing.T) {
+	// vector taken from https://github.com/TBD54566975/web5-js/blob/dids-new-crypto/packages/crypto/tests/fixtures/test-vectors/secp256k1/bytes-to-public-key.json
+	jwk := jwk.JWK{
+		KTY: "EC",
+		CRV: ecdsa.SECP256K1JWACurve,
+		X:   "eb5mfvncu6xVoGKVzocLBwKb_NstzijZWfKBWxb4F5g",
+		Y:   "SDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj_sQ1Lg",
+	}
+
+	pubKeyBytes, err := ecdsa.PublicKeyToBytes(jwk)
+	assert.NoError(t, err)
+
+	pubKeyHex := hex.EncodeToString(pubKeyBytes)
+	expected := "0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8"
+
+	assert.Equal(t, pubKeyHex, expected)
+}
+
+func TestSECP256K1PublicKeyToBytes_Bad(t *testing.T) {
+	vectors := []jwk.JWK{
+		{
+			KTY: "EC",
+			CRV: ecdsa.SECP256K1JWACurve,
+			X:   "eb5mfvncu6xVoGKVzocLBwKb_NstzijZWfKBWxb4F5g",
+		},
+		{
+			KTY: "EC",
+			CRV: ecdsa.SECP256K1JWACurve,
+			Y:   "eb5mfvncu6xVoGKVzocLBwKb_NstzijZWfKBWxb4F5g",
+		},
+		{
+			KTY: "EC",
+			CRV: ecdsa.SECP256K1JWACurve,
+			X:   "=///",
+			Y:   "SDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj_sQ1Lg",
+		},
+		{
+			KTY: "EC",
+			CRV: ecdsa.SECP256K1JWACurve,
+			X:   "eb5mfvncu6xVoGKVzocLBwKb_NstzijZWfKBWxb4F5g",
+			Y:   "=///",
+		},
+		{
+			KTY: "EC",
+			CRV: ecdsa.SECP256K1JWACurve,
+			X:   "eb5mfvncu6xVoGKVzocLBwKb_NstzijZWfKBWxb4F5g",
+			Y:   "SDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj_sQ1Lg2",
+		},
+	}
+
+	for _, vec := range vectors {
+		pubKeyBytes, err := ecdsa.PublicKeyToBytes(vec)
+		assert.Error(t, err)
+		assert.Equal(t, pubKeyBytes, nil)
+	}
 }

--- a/crypto/dsa/eddsa/ed25519.go
+++ b/crypto/dsa/eddsa/ed25519.go
@@ -61,3 +61,17 @@ func ED25519BytesToPublicKey(input []byte) (jwk.JWK, error) {
 		X:   base64.RawURLEncoding.EncodeToString(input),
 	}, nil
 }
+
+// ED25519PublicKeyToBytes converts the provided public key to bytes
+func ED25519PublicKeyToBytes(publicKey jwk.JWK) ([]byte, error) {
+	if publicKey.X == "" {
+		return nil, fmt.Errorf("x must be set")
+	}
+
+	publicKeyBytes, err := base64.RawURLEncoding.DecodeString(publicKey.X)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode x %w", err)
+	}
+
+	return publicKeyBytes, nil
+}

--- a/crypto/dsa/eddsa/ed25519_test.go
+++ b/crypto/dsa/eddsa/ed25519_test.go
@@ -1,11 +1,13 @@
 package eddsa_test
 
 import (
+	"encoding/base64"
 	"encoding/hex"
 	"testing"
 
 	"github.com/alecthomas/assert/v2"
 	"github.com/tbd54566975/web5-go/crypto/dsa/eddsa"
+	"github.com/tbd54566975/web5-go/jwk"
 )
 
 func TestED25519BytesToPublicKey_Bad(t *testing.T) {
@@ -26,4 +28,40 @@ func TestED25519BytesToPublicKey_Good(t *testing.T) {
 	assert.Equal(t, jwk.KTY, eddsa.KeyType)
 	assert.Equal(t, jwk.CRV, eddsa.ED25519JWACurve)
 	assert.Equal(t, jwk.X, "fU0Of2FTpptiQrUiq77mhf2kQg-INLEIw72uNp71Sfo")
+}
+
+func TestED25519PublicKeyToBytes(t *testing.T) {
+	// vector taken from: https://github.com/TBD54566975/web5-spec/blob/main/test-vectors/crypto_ed25519/sign.json
+	jwk := jwk.JWK{
+		KTY: "OKP",
+		CRV: eddsa.ED25519JWACurve,
+		X:   "11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo",
+	}
+
+	pubKeyBytes, err := eddsa.ED25519PublicKeyToBytes(jwk)
+	assert.NoError(t, err)
+
+	pubKeyB64URL := base64.RawURLEncoding.EncodeToString(pubKeyBytes)
+	assert.Equal(t, jwk.X, pubKeyB64URL)
+}
+
+func TestED25519PublicKeyToBytes_Bad(t *testing.T) {
+	vectors := []jwk.JWK{
+		{
+			KTY: "OKP",
+			CRV: eddsa.ED25519JWACurve,
+		},
+		{
+			KTY: "OKP",
+			CRV: eddsa.ED25519JWACurve,
+			X:   "=/---",
+		},
+	}
+
+	for _, jwk := range vectors {
+		pubKeyBytes, err := eddsa.ED25519PublicKeyToBytes(jwk)
+		assert.Error(t, err)
+
+		assert.Equal(t, nil, pubKeyBytes)
+	}
 }

--- a/crypto/dsa/eddsa/eddsa.go
+++ b/crypto/dsa/eddsa/eddsa.go
@@ -70,6 +70,15 @@ func BytesToPublicKey(algorithmID string, input []byte) (jwk.JWK, error) {
 	}
 }
 
+func PublicKeyToBytes(publicKey jwk.JWK) ([]byte, error) {
+	switch publicKey.CRV {
+	case ED25519JWACurve:
+		return ED25519PublicKeyToBytes(publicKey)
+	default:
+		return nil, fmt.Errorf("unsupported curve: %s", publicKey.CRV)
+	}
+}
+
 func SupportsAlgorithmID(id string) bool {
 	return algorithmIDs[id]
 }


### PR DESCRIPTION
# Overview
* added function to convert `secp256k1` public key jwk -> bytes
* added function to convert `ed25519` public key jwk -> bytes
* added functions to convert public key jwk -> bytes  to `ecdsa`, `eddsa`, and `dsa`

> [!IMPORTANT]
> Adding this functionality for upcoming `did:dht` creation PR

# Usage

## High Level API
```go
package main

import (
	"encoding/hex"
	"fmt"

	"github.com/tbd54566975/web5-go/crypto/dsa"
	"github.com/tbd54566975/web5-go/crypto/dsa/ecdsa"
	"github.com/tbd54566975/web5-go/jwk"
)

func main() {
	jwk := jwk.JWK{
		KTY: "EC",
		CRV: ecdsa.SECP256K1JWACurve,
		X:   "eb5mfvncu6xVoGKVzocLBwKb_NstzijZWfKBWxb4F5g",
		Y:   "SDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj_sQ1Lg",
	}

	pubKeyBytes, err := dsa.PublicKeyToBytes(jwk)
	if err != nil {
		panic(err)
	}

	fmt.Println(hex.EncodeToString(pubKeyBytes))
}
```

# Internal Dialogue
I really want to restructure the crypto package to be a bit cleaner. Specifically,
* pull `secp256k1` and `ed25519` up and into their own packages. These key types are applicable beyond DSA (e.g. ECDH)
* Potentially implement a registration pattern for the higher level APIs