### PR TITLE
Update `PortableDID` Part 1

### DIFF
--- a/dids/did/bearerdid_test.go
+++ b/dids/did/bearerdid_test.go
@@ -10,30 +10,29 @@ import (
 	"github.com/tbd54566975/web5-go/jws"
 )
 
-func Test_ToKeys(t *testing.T) {
+func TestToPortableDID(t *testing.T) {
 	did, err := didjwk.Create()
 	assert.NoError(t, err)
 
-	portableDID, err := did.ToKeys()
+	portableDID, err := did.ToPortableDID()
 	assert.NoError(t, err)
 
 	assert.Equal[string](t, did.URI, portableDID.URI)
-	assert.True(t, len(portableDID.VerificationMethod) == 1, "expected 1 key")
+	assert.True(t, len(portableDID.PrivateKeys) == 1, "expected 1 key")
 
-	vm := portableDID.VerificationMethod[0]
+	key := portableDID.PrivateKeys[0]
 
-	assert.NotEqual(t, *vm.PublicKeyJWK, jwk.JWK{}, "expected publicKeyJwk to not be empty")
-	assert.NotEqual(t, vm.PrivateKeyJWK, jwk.JWK{}, "expected privateKeyJWK to not be empty")
+	assert.NotEqual(t, key, jwk.JWK{}, "expected key to not be empty")
 }
 
-func TestBearerDIDFromKeys(t *testing.T) {
+func TestFromPortableDID(t *testing.T) {
 	bearerDID, err := didjwk.Create()
 	assert.NoError(t, err)
 
-	portableDID, err := bearerDID.ToKeys()
+	portableDID, err := bearerDID.ToPortableDID()
 	assert.NoError(t, err)
 
-	importedDID, err := did.BearerDIDFromKeys(portableDID)
+	importedDID, err := did.FromPortableDID(portableDID)
 	assert.NoError(t, err)
 
 	compactJWS, err := jws.Sign("hi", bearerDID)

--- a/dids/did/portabledid.go
+++ b/dids/did/portabledid.go
@@ -1,0 +1,22 @@
+package did
+
+import (
+	"github.com/tbd54566975/web5-go/dids/didcore"
+	"github.com/tbd54566975/web5-go/jwk"
+)
+
+// PortableDID is a serializable BearerDID. VerificationMethod contains the private key
+// of each verification method that the BearerDID's key manager contains
+type PortableDID struct {
+	// URI is the DID string as per https://www.w3.org/TR/did-core/#did-syntax
+	URI string `json:"uri"`
+	// PrivateKeys is an array of private keys associated to the BearerDID's verification methods
+	// Note: PrivateKeys will be empty if the BearerDID was created using a KeyManager that does not
+	// support exporting private keys (e.g. HSM based KeyManagers)
+	PrivateKeys []jwk.JWK `json:"privateKeys"`
+	// Document is the DID Document associated to the BearerDID
+	Document didcore.Document `json:"document"`
+	// Metadata is a map that can be used to store additional method specific data
+	// that is necessary to inflate a BearerDID from a PortableDID
+	Metadata map[string]interface{} `json:"metadata"`
+}

--- a/jws/README.md
+++ b/jws/README.md
@@ -5,7 +5,7 @@
 - [Features](#features)
 - [Usage](#usage)
   - [Signing:](#signing)
-  - [Detatched Content](#detatched-content)
+  - [Detached Content](#detached-content)
   - [Verifying](#verifying)
   - [Directory Structure](#directory-structure)
     - [Rationale](#rationale)
@@ -47,9 +47,9 @@ func main() {
 }
 ```
 
-## Detatched Content
+## Detached Content
 
-returning a JWS with detatched content can be done like so:
+returning a JWS with detached content can be done like so:
 
 ```go
 package main
@@ -69,7 +69,7 @@ func main() {
 
     payload := map[string]interface{}{"hello": "world"}
     
-    compactJWS, err := jws.Sign(payload, did, Detatched(true))
+    compactJWS, err := jws.Sign(payload, did, Detached(true))
     if err != nil {
         fmt.Printf("failed to sign: %v", err)
         return

--- a/jws/jws.go
+++ b/jws/jws.go
@@ -73,11 +73,11 @@ func Purpose(purpose string) SignOpts {
 	}
 }
 
-// DetatchedPayload is an option that can be passed to [github.com/tbd54566975/web5-go/jws.Sign].
+// DetachedPayload is an option that can be passed to [github.com/tbd54566975/web5-go/jws.Sign].
 // It is used to indicate whether the payload should be included in the signature.
 // More details can be found in [Specification].
 // [Specification]: https://datatracker.ietf.org/doc/html/rfc7515#appendix-F
-func DetatchedPayload(detached bool) SignOpts {
+func DetachedPayload(detached bool) SignOpts {
 	return func(opts *signOpts) {
 		opts.detached = detached
 	}
@@ -92,17 +92,12 @@ func Sign(payload JWSPayload, did did.BearerDID, opts ...SignOpts) (string, erro
 		opt(&o)
 	}
 
-	resolutionResult, err := dids.Resolve(did.URI)
-	if err != nil {
-		return "", fmt.Errorf("failed to resolve DID: %w", err)
-	}
-
 	var verificationMethodID string
 	switch o.purpose {
 	case "assertionMethod":
-		verificationMethodID = resolutionResult.Document.AssertionMethod[0]
+		verificationMethodID = did.Document.AssertionMethod[0]
 	case "authentication":
-		verificationMethodID = resolutionResult.Document.Authentication[0]
+		verificationMethodID = did.Document.Authentication[0]
 	default:
 		return "", fmt.Errorf("unsupported purpose: %s", o.purpose)
 	}
@@ -112,7 +107,7 @@ func Sign(payload JWSPayload, did did.BearerDID, opts ...SignOpts) (string, erro
 	}
 
 	var verificationMethod didcore.VerificationMethod
-	for _, vm := range resolutionResult.Document.VerificationMethod {
+	for _, vm := range did.Document.VerificationMethod {
 		if vm.ID == verificationMethodID {
 			verificationMethod = vm
 			break


### PR DESCRIPTION
# Overview
This PR is part 1 of 3 to introduce changes discussed here: https://github.com/TBD54566975/web5-spec/issues/112#issuecomment-1924691567. 

> [!IMPORTANT]
> Prioritizing the changes in this first PR because it includes stuff that i need in order to implement `did:web` which is necessary to unblock a bunch of work for the upcoming week. Details on what was and wasn't included in the sections below

# What's Included 
**changed `ToKeys` and `FromKeys` to `ToPortableDID` and `FromPortableDID` respectively**

`ToKeys` and `FromKeys` no longer made sense because `PortableDID` includes more than just keys.

---

**`ToPortableDID` no longer throws if the `BearerDID`'s  Key Manager cannot export keys. Instead, `PrivateKeys` is omitted.**

This makes it so `BearerDID` created using HSM based key manager's can still be exported to a `PortableDID`. This is useful because there's still necessary state even when re-inflating a `BearerDID` with an HSM based key manager

---

**added `Document` field to `PortableDID`**

Including the DID Document allows us to import a DID without making potential network calls and also does not require DIDs to be published prior to exporting them. 

---

**changed `VerificationMethod` field to `PrivateKeys`**

Now that we have the DID Document, including what was previously in `VerificationMethod` is duplicative

added `Metadata`. Used to store method-specific properties

---

# What's Not Included

**`FromPortableDID` doesn't accept an optional `KeyManager` arg yet**

Will likely move this function to method-specific packages to accommodate method-specific metadata. Also haven't decided how to share functional options yet. 

---

**`PortableDID.Metadata` doesn't include an explicit `published` property yet.**

This is simply because i can't remember a detail we discussed in the meeting where we decided all of these thangs. will double back with @frankhinek and @amika-sq and then make the appropriate change


# What's Weird Right Now

`FromPortableDID` and `ToPortableDID` are in the `did` package right now which makes calling these functions from outside the package look like `did.FromPortableDID` and `did.ToPortableDID`. It's not evident what representation of DID you're going _to_ or _from_ just by reading the line of code. 