### PR TITLE
`did:web` creation

### DIFF
--- a/dids/didweb/didweb.go
+++ b/dids/didweb/didweb.go
@@ -2,6 +2,7 @@ package didweb
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/tbd54566975/web5-go/crypto"
 	"github.com/tbd54566975/web5-go/crypto/dsa"
@@ -9,22 +10,39 @@ import (
 	"github.com/tbd54566975/web5-go/dids/didcore"
 )
 
+// CreateOption is the type returned from each individual option function
+type CreateOption func(*createOptions)
+
+// createOptions is a struct to hold options for creating a new 'did:web' BearerDID.
+// Each option has a corresponding function that can be used by the caller to set the value of the option.
+type createOptions struct {
+	services    []didcore.Service
+	privateKeys []privateKeyOption
+	keyManager  crypto.KeyManager
+	alsoKnownAs []string
+	controllers []string
+}
+
+// privateKeyOption is a struct to hold options for creating a new private key.
 type privateKeyOption struct {
 	algorithmID string
 	purposes    []string
 }
 
-type createOptions struct {
-	services    []didcore.Service
-	privateKeys []privateKeyOption
-	keyManager  crypto.KeyManager
-}
-
-type CreateOption func(*createOptions)
-
+// Service is used to add a service to the DID being created with the [Create] function.
+// Note: Service can be passed to [Create] multiple times to add multiple services.
 func Service(id string, svcType string, endpoint string) CreateOption {
 	return func(o *createOptions) {
-		svc := didcore.Service{ID: id, Type: svcType, ServiceEndpoint: endpoint}
+		// ensure that id follows relative DID URL requirements defined in did core spec:
+		// https://www.w3.org/TR/did-core/#relative-did-urls
+		var svcID string
+		if id[0] == '#' || strings.HasPrefix(id, "did:") {
+			svcID = id
+		} else {
+			svcID = "#" + id
+		}
+
+		svc := didcore.Service{ID: svcID, Type: svcType, ServiceEndpoint: endpoint}
 		if o.services == nil {
 			o.services = make([]didcore.Service, 0)
 		}
@@ -33,6 +51,9 @@ func Service(id string, svcType string, endpoint string) CreateOption {
 	}
 }
 
+// PrivateKey is used to add a private key to the DID being created with the [Create] function.
+// Each PrivateKey provided will be used to generate a private key in the key manager and then
+// added to the DID Document as a VerificationMethod.
 func PrivateKey(algorithmID string, purposes ...string) CreateOption {
 	return func(o *createOptions) {
 		keyOpts := privateKeyOption{algorithmID: algorithmID, purposes: purposes}
@@ -45,12 +66,32 @@ func PrivateKey(algorithmID string, purposes ...string) CreateOption {
 	}
 }
 
+// KeyManager is used to set the key manager that will be used to generate the private keys for the DID.
 func KeyManager(km crypto.KeyManager) CreateOption {
 	return func(o *createOptions) {
 		o.keyManager = km
 	}
 }
 
+// AlsoKnownAs is used to set the 'alsoKnownAs' property of the DID Document.
+// more details here: https://www.w3.org/TR/did-core/#also-known-as
+func AlsoKnownAs(aka ...string) CreateOption {
+	return func(o *createOptions) {
+		o.alsoKnownAs = aka
+	}
+}
+
+// Controllers is used to set the 'controller' property of the DID Document.
+// more details here: https://www.w3.org/TR/did-core/#controller
+func Controllers(controllers ...string) CreateOption {
+	return func(o *createOptions) {
+		o.controllers = controllers
+	}
+}
+
+// Create creates a new 'did:web' BearerDID with the given domain and options provided.
+// If no options are provided, a default key manager will be used to generate a single ED25519 key pair.
+// The resulting public key will be added to the DID Document as a VerificationMethod.
 func Create(domain string, opts ...CreateOption) (_did.BearerDID, error) {
 	options := &createOptions{
 		keyManager: crypto.NewLocalKeyManager(),
@@ -74,7 +115,15 @@ func Create(domain string, opts ...CreateOption) (_did.BearerDID, error) {
 		ID: did.URI,
 	}
 
-	for _, keyOpts := range options.privateKeys {
+	if len(options.alsoKnownAs) > 0 {
+		document.AlsoKnownAs = options.alsoKnownAs
+	}
+
+	if len(options.controllers) > 0 {
+		document.Controller = options.controllers
+	}
+
+	for idx, keyOpts := range options.privateKeys {
 		keyID, err := options.keyManager.GeneratePrivateKey(keyOpts.algorithmID)
 		if err != nil {
 			return _did.BearerDID{}, fmt.Errorf("failed to generate %s private key: %w", keyOpts.algorithmID, err)
@@ -85,13 +134,8 @@ func Create(domain string, opts ...CreateOption) (_did.BearerDID, error) {
 			return _did.BearerDID{}, fmt.Errorf("failed to get public key for private key %s: %w", keyID, err)
 		}
 
-		vmID, err := publicKeyJWK.ComputeThumbprint()
-		if err != nil {
-			return _did.BearerDID{}, fmt.Errorf("failed to generate verification method id: %w", err)
-		}
-
 		vm := didcore.VerificationMethod{
-			ID:           "#" + vmID,
+			ID:           "#" + fmt.Sprint(idx),
 			Type:         "JsonWebKey2020",
 			Controller:   did.URI,
 			PublicKeyJwk: &publicKeyJWK,

--- a/dids/didweb/didweb.go
+++ b/dids/didweb/didweb.go
@@ -1,0 +1,113 @@
+package didweb
+
+import (
+	"fmt"
+
+	"github.com/tbd54566975/web5-go/crypto"
+	"github.com/tbd54566975/web5-go/crypto/dsa"
+	_did "github.com/tbd54566975/web5-go/dids/did"
+	"github.com/tbd54566975/web5-go/dids/didcore"
+)
+
+type privateKeyOption struct {
+	algorithmID string
+	purposes    []string
+}
+
+type createOptions struct {
+	services    []didcore.Service
+	privateKeys []privateKeyOption
+	keyManager  crypto.KeyManager
+}
+
+type CreateOption func(*createOptions)
+
+func Service(id string, svcType string, endpoint string) CreateOption {
+	return func(o *createOptions) {
+		svc := didcore.Service{ID: id, Type: svcType, ServiceEndpoint: endpoint}
+		if o.services == nil {
+			o.services = make([]didcore.Service, 0)
+		}
+
+		o.services = append(o.services, svc)
+	}
+}
+
+func PrivateKey(algorithmID string, purposes ...string) CreateOption {
+	return func(o *createOptions) {
+		keyOpts := privateKeyOption{algorithmID: algorithmID, purposes: purposes}
+
+		if o.privateKeys == nil {
+			o.privateKeys = make([]privateKeyOption, 0)
+		}
+
+		o.privateKeys = append(o.privateKeys, keyOpts)
+	}
+}
+
+func KeyManager(km crypto.KeyManager) CreateOption {
+	return func(o *createOptions) {
+		o.keyManager = km
+	}
+}
+
+func Create(domain string, opts ...CreateOption) (_did.BearerDID, error) {
+	options := &createOptions{
+		keyManager: crypto.NewLocalKeyManager(),
+		privateKeys: []privateKeyOption{
+			{
+				algorithmID: dsa.AlgorithmIDED25519,
+			},
+		},
+	}
+
+	for _, opt := range opts {
+		opt(options)
+	}
+
+	did, err := _did.Parse("did:web:" + domain)
+	if err != nil {
+		return _did.BearerDID{}, fmt.Errorf("invalid domain: %w", err)
+	}
+
+	document := didcore.Document{
+		ID: did.URI,
+	}
+
+	for _, keyOpts := range options.privateKeys {
+		keyID, err := options.keyManager.GeneratePrivateKey(keyOpts.algorithmID)
+		if err != nil {
+			return _did.BearerDID{}, fmt.Errorf("failed to generate %s private key: %w", keyOpts.algorithmID, err)
+		}
+
+		publicKeyJWK, err := options.keyManager.GetPublicKey(keyID)
+		if err != nil {
+			return _did.BearerDID{}, fmt.Errorf("failed to get public key for private key %s: %w", keyID, err)
+		}
+
+		vmID, err := publicKeyJWK.ComputeThumbprint()
+		if err != nil {
+			return _did.BearerDID{}, fmt.Errorf("failed to generate verification method id: %w", err)
+		}
+
+		vm := didcore.VerificationMethod{
+			ID:           "#" + vmID,
+			Type:         "JsonWebKey2020",
+			Controller:   did.URI,
+			PublicKeyJwk: &publicKeyJWK,
+		}
+
+		document.AddVerificationMethod(vm, didcore.Purposes(keyOpts.purposes...))
+
+	}
+
+	for _, svc := range options.services {
+		document.AddService(&svc)
+	}
+
+	return _did.BearerDID{
+		DID:        did,
+		KeyManager: options.keyManager,
+		Document:   document,
+	}, nil
+}

--- a/dids/didweb/didweb_test.go
+++ b/dids/didweb/didweb_test.go
@@ -16,10 +16,12 @@ func TestCreate(t *testing.T) {
 	assert.NotEqual(t, didcore.Document{}, bearerDID.Document)
 }
 
-func TestCreate_WithServiceOption(t *testing.T) {
+func TestCreate_WithOptions(t *testing.T) {
 	bearerDID, err := didweb.Create(
 		"localhost:8080",
 		didweb.Service("pfi", "PFI", "http://localhost:8080"),
+		didweb.AlsoKnownAs("did:example:123"),
+		didweb.Controllers("did:example:123"),
 	)
 
 	assert.NoError(t, err)
@@ -30,7 +32,11 @@ func TestCreate_WithServiceOption(t *testing.T) {
 
 	svc := document.Service[0]
 	assert.NotEqual(t, didcore.Service{}, *svc)
-	assert.Equal(t, "pfi", svc.ID)
+	assert.Equal(t, "#pfi", svc.ID)
 	assert.Equal(t, "PFI", svc.Type)
 	assert.Equal(t, "http://localhost:8080", svc.ServiceEndpoint)
+
+	assert.Equal(t, "did:example:123", document.AlsoKnownAs[0])
+	assert.Equal(t, "did:example:123", document.Controller[0])
+
 }

--- a/dids/didweb/didweb_test.go
+++ b/dids/didweb/didweb_test.go
@@ -14,6 +14,10 @@ func TestCreate(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.NotEqual(t, didcore.Document{}, bearerDID.Document)
+
+	document := bearerDID.Document
+	assert.Equal(t, "did:web:localhost%3A8080", document.ID)
+	assert.Equal(t, 1, len(document.VerificationMethod))
 }
 
 func TestCreate_WithOptions(t *testing.T) {

--- a/dids/didweb/didweb_test.go
+++ b/dids/didweb/didweb_test.go
@@ -1,0 +1,36 @@
+package didweb_test
+
+import (
+	"testing"
+
+	"github.com/alecthomas/assert/v2"
+	"github.com/tbd54566975/web5-go/dids/did"
+	"github.com/tbd54566975/web5-go/dids/didcore"
+	"github.com/tbd54566975/web5-go/dids/didweb"
+)
+
+func TestCreate(t *testing.T) {
+	bearerDID, err := didweb.Create("localhost:8080")
+	assert.NoError(t, err)
+
+	assert.NotEqual(t, didcore.Document{}, bearerDID.Document)
+}
+
+func TestCreate_WithServiceOption(t *testing.T) {
+	bearerDID, err := didweb.Create(
+		"localhost:8080",
+		didweb.Service("pfi", "PFI", "http://localhost:8080"),
+	)
+
+	assert.NoError(t, err)
+	assert.NotEqual(t, did.BearerDID{}, bearerDID)
+
+	document := bearerDID.Document
+	assert.Equal(t, 1, len(document.Service))
+
+	svc := document.Service[0]
+	assert.NotEqual(t, didcore.Service{}, *svc)
+	assert.Equal(t, "pfi", svc.ID)
+	assert.Equal(t, "PFI", svc.Type)
+	assert.Equal(t, "http://localhost:8080", svc.ServiceEndpoint)
+}


### PR DESCRIPTION
# Overview
This PR is a speed-run implementation of `did:web` creation with the primary motivation of unblocking KCC issuance prototype while we wait for `did:dht` creation to land

> [!WARNING]
> the current implementation is not nearly as defensive as it could be (e.g. checking for zero values). Primarily looking to unblock our KCC issuance prototype efforts and coming back around to finish this out

# Usage

At a minimum, the domain for which a did should be created is required. 

> [!IMPORTANT]
> If no options are provided, a default key manager will be used to generate a single `Ed25519` key pair. The resulting public key will be added to the DID Document as a Verification Method.


## Create with no options
```go
package main

import (
    "encoding/json"
    "fmt"

    "github.com/tbd54566975/web5-go/dids/didweb"
)

func main() {
    bearerDID, err := didweb.Create("localhost:8080")
    if err != nil {
        panic(err)
    }

    fmt.Printf("DID: %+v\n", bearerDID)

    bytes, err := json.MarshalIndent(bearerDID.Document, "", "  ")
    if err != nil {
        panic(err)
    }

    fmt.Printf("DID Document: %+v\n", string(bytes))
}
```

### Output
```
DID: did:web:localhost%3A8080
DID Document: {
  "id": "did:web:localhost%3A8080",
  "verificationMethod": [
    {
      "id": "#0",
      "type": "JsonWebKey2020",
      "controller": "did:web:localhost%3A8080",
      "publicKeyJwk": {
        "kty": "OKP",
        "crv": "Ed25519",
        "x": "I9XaZmu8cifzvj0Zj7cxSWpzx5E_VhSEldXQrDexTqQ"
      }
    }
  ]
}
```

## Create With Options
Options can be provided to `Create` in order to add/set additional properties on the resulting DID Method

```go
package main

import (
    "encoding/json"
    "fmt"

    "github.com/tbd54566975/web5-go/dids/didweb"
)

func main() {
    bearerDID, err := didweb.Create(
        "localhost:8080",
        didweb.Service("pfi", "PFI", "http://localhost:8080/tbdex"),
        didweb.Service("idv", "IDV", "http://localhost:8080/idv"),
    )

    if err != nil {
        panic(err)
    }

    fmt.Printf("DID: %+v\n", bearerDID)

    bytes, err := json.MarshalIndent(bearerDID.Document, "", "  ")
    if err != nil {
        panic(err)
    }

    fmt.Printf("DID Document: %+v\n", string(bytes))
}
```

> [!IMPORTANT]
> The `Service` and `PrivateKey` option can be provided multiple times to add multiple services or verification methods respectively

### Output
```
DID: did:web:localhost%3A8080
DID Document: {
  "id": "did:web:localhost%3A8080",
  "verificationMethod": [
    {
      "id": "#0",
      "type": "JsonWebKey2020",
      "controller": "did:web:localhost%3A8080",
      "publicKeyJwk": {
        "kty": "OKP",
        "crv": "Ed25519",
        "x": "5z5OVpmIJ5gmDtJcgXiRGpgQARhwUxx0mnCAAq_mZgc"
      }
    }
  ],
  "service": [
    {
      "id": "#idv",
      "type": "IDV",
      "serviceEndpoint": "http://localhost:8080/idv"
    },
    {
      "id": "#idv",
      "type": "IDV",
      "serviceEndpoint": "http://localhost:8080/idv"
    }
  ]
}
```


# Notes

## `Create` _does not_ publish the DID anywhere. 

"registering" or "publishing" a `did:web` is done by hosting the resulting DID document at `${domain}/.well-known/did.json`. An example of this is linkedin's DID: [did:web:www.linkedin.com](https://www.linkedin.com/.well-known/did.json)


##  Requesting feedback for the options approach used

Let me know what y'all think! there's a bit of an inconsistency here in that multiple `Service` arguments need to be provided whereas the `Controllers` option allows any number of strings to be provided using variadic args.

> [!NOTE]
> i believe `web5-js` uses `verificationMethods` instead of `privateKey` in its did method `create` methods. Just wanted to see what it would look like. lmk what you think @frankhinek @amika-sq 

> [!NOTE]
> It's likely that many of these options can be reused for other did method creation functions e.g. `did:dht`. I didn't want to jump the gun though because the options don't apply to _all_ did methods e.g. `did:jwk`