### PR TITLE
Add jwt.DecodeJWTClaims function

### DIFF
--- a/jws/jws.go
+++ b/jws/jws.go
@@ -40,8 +40,8 @@ func (j Header) Base64UrlEncode() string {
 	return base64.RawURLEncoding.EncodeToString(bytes)
 }
 
-// DecodeJWSHeader decodes the base64url encoded JWS header.
-func DecodeJWSHeader(base64UrlEncodedHeader string) (Header, error) {
+// DecodeHeader decodes the base64url encoded JWS header.
+func DecodeHeader(base64UrlEncodedHeader string) (Header, error) {
 	bytes, err := base64.RawURLEncoding.DecodeString(base64UrlEncodedHeader)
 	if err != nil {
 		return Header{}, err
@@ -171,7 +171,7 @@ func Verify(compactJWS string) (bool, error) {
 	}
 
 	base64UrlEncodedHeader := parts[0]
-	header, err := DecodeJWSHeader(base64UrlEncodedHeader)
+	header, err := DecodeHeader(base64UrlEncodedHeader)
 	if err != nil {
 		return false, fmt.Errorf("malformed JWS. Failed to decode header: %s", err.Error())
 	}

--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -171,3 +171,19 @@ func Verify(jwt string) (bool, error) {
 
 	return jws.Verify(jwt)
 }
+
+// DecodeJWTClaims decodes the base64url encoded JWT claims.
+func DecodeJWTClaims(base64UrlEncodedClaims string) (Claims, error) {
+	bytes, err := base64.RawURLEncoding.DecodeString(base64UrlEncodedClaims)
+	if err != nil {
+		return Claims{}, err
+	}
+
+	var claims Claims
+	err = json.Unmarshal(bytes, &claims)
+	if err != nil {
+		return Claims{}, err
+	}
+
+	return claims, nil
+}

--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -172,8 +172,8 @@ func Verify(jwt string) (bool, error) {
 	return jws.Verify(jwt)
 }
 
-// DecodeJWTClaims decodes the base64url encoded JWT claims.
-func DecodeJWTClaims(base64UrlEncodedClaims string) (Claims, error) {
+// DecodeClaims decodes the base64url encoded JWT claims.
+func DecodeClaims(base64UrlEncodedClaims string) (Claims, error) {
 	bytes, err := base64.RawURLEncoding.DecodeString(base64UrlEncodedClaims)
 	if err != nil {
 		return Claims{}, err

--- a/jwt/jwt_test.go
+++ b/jwt/jwt_test.go
@@ -103,7 +103,7 @@ func TestDecodeJWTClaims(t *testing.T) {
 	assert.NoError(t, err)
 
 	parts := strings.Split(signedJwt, ".")
-	assert.Equal(t, len(parts), 3, "expected 3 parts in JWT")
+	assert.Equal(t, 3, len(parts), "expected 3 parts in JWT")
 	base64UrlEncodedClaims := parts[1]
 
 	decodedClaims, err := jwt.DecodeJWTClaims(base64UrlEncodedClaims)

--- a/jwt/jwt_test.go
+++ b/jwt/jwt_test.go
@@ -89,7 +89,7 @@ func TestVerify_BadClaims(t *testing.T) {
 	assert.False(t, verified, "expected !verified")
 }
 
-func TestDecodeJWTClaims(t *testing.T) {
+func TestDecodeClaims(t *testing.T) {
 	did, err := didjwk.Create()
 	assert.NoError(t, err)
 
@@ -106,7 +106,7 @@ func TestDecodeJWTClaims(t *testing.T) {
 	assert.Equal(t, 3, len(parts), "expected 3 parts in JWT")
 	base64UrlEncodedClaims := parts[1]
 
-	decodedClaims, err := jwt.DecodeJWTClaims(base64UrlEncodedClaims)
+	decodedClaims, err := jwt.DecodeClaims(base64UrlEncodedClaims)
 	assert.NoError(t, err)
 	assert.Equal(t, claims.Issuer, decodedClaims.Issuer)
 	assert.Equal(t, claims.Misc["c_nonce"], decodedClaims.Misc["c_nonce"])

--- a/jwt/jwt_test.go
+++ b/jwt/jwt_test.go
@@ -3,6 +3,7 @@ package jwt_test
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/alecthomas/assert/v2"
@@ -86,4 +87,27 @@ func TestVerify_BadClaims(t *testing.T) {
 	verified, err := jwt.Verify(input)
 	assert.Error(t, err)
 	assert.False(t, verified, "expected !verified")
+}
+
+func TestDecodeJWTClaims(t *testing.T) {
+	did, err := didjwk.Create()
+	assert.NoError(t, err)
+
+	nonce := "abcd123"
+	claims := jwt.Claims{
+		Issuer: did.ID,
+		Misc:   map[string]interface{}{"c_nonce": nonce},
+	}
+
+	signedJwt, err := jwt.Sign(claims, did)
+	assert.NoError(t, err)
+
+	parts := strings.Split(signedJwt, ".")
+	assert.Equal(t, len(parts), 3, "expected 3 parts in JWT")
+	base64UrlEncodedClaims := parts[1]
+
+	decodedClaims, err := jwt.DecodeJWTClaims(base64UrlEncodedClaims)
+	assert.NoError(t, err)
+	assert.Equal(t, claims.Issuer, decodedClaims.Issuer)
+	assert.Equal(t, claims.Misc["c_nonce"], decodedClaims.Misc["c_nonce"])
 }


### PR DESCRIPTION
# Overview
Given the developer has a JWT, and they extract the base64 URL encoded claims, they can call this function to decode into the `Claims` type

# Usage

```go
package main

import (
    "encoding/json"
    "fmt"

    "github.com/tbd54566975/web5-go/jwt"
)

func main() {
    	signedJwt := "eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDpqd2s6ZXlKcmRIa2lPaUpQUzFBaUxDSmpjbllpT2lKRlpESTFOVEU1SWl3aWVDSTZJbFpyU3pKclRscDVVREY0WVZwUFoyZHBjREY2VTJwc1JXTnNTakZSTVhSQmMxRkJhVU5YUW1GaVgyOGlmUSMwIn0." +
	"eyJjX25vbmNlIjoiYWJjZDEyMyIsImlzcyI6ImV5SnJkSGtpT2lKUFMxQWlMQ0pqY25ZaU9pSkZaREkxTlRFNUlpd2llQ0k2SWxaclN6SnJUbHA1VURGNFlWcFBaMmRwY0RGNlUycHNSV05zU2pGUk1YUkJjMUZCYVVOWFFtRmlYMjhpZlEifQ." +
	"O434_IlnJOYbcIsHkVcOyKLxVvcfHvcg6tZL_gIU2TAY6qFiaPZ_w6upSzIl-I8JXYBytzR_8BfCq4P3che1Bg"

	parts := strings.Split(signedJwt, ".")
	
	base64UrlEncodedClaims := parts[1]

	decodedClaims, err := jwt.DecodeJWTClaims(base64UrlEncodedClaims)

	if err != nil {
		panic(err)
	}

	bytes, err := json.MarshalIndent(decodedClaims, "", "  ")
	if err != nil {
			panic(err)
	}

	fmt.Printf("Claims: %+v\n", string(bytes))
}
```

# Additional Ideas

I followed the same pattern as [we have with `jws.DecodeJWSHeader()` from here](https://github.com/TBD54566975/web5-go/blob/947009d0580a00592c3ab04d5a3f0cf31ab502cc/jws/jws.go#L44). But, we may want to go a add another layer here. Namely, the developer consuming this library (let's call them Alice), will likely have a full signed JWT string (which may originate from our `jwt.Sign()` function). And Alice may want both the headers & the claims (often times specs such as OID4VCI have verification rulesets which include both the header & the claims).

Rather than having the developer first do this...

```go
parts := strings.Split(signedJwt, ".")
// todo error handle
base64UrlEncodedHeader := parts[0]
base64UrlEncodedClaims := parts[1]
```

...we may want to embed that in a function, as well as also executing a call to `jwt.Verify()`. I originally had the idea that we could create a function like this...

```go
type JWT struct {
	Header jws.Header
	Claims jwt.Claims
}

func ParseJWT(signedJwt string) (JWT, error) {
	verified, err := jwt.Verify(signedJwt)
	if err != nil {
		// TODO handle error
	}
	if !verified {
		// TODO handle error
	}
	
	parts := strings.Split(signedJwt, ".")
	if len(parts) != 3 {
		// TODO handle error
	}
	
	base64UrlEncodedHeader := parts[0]
	base64UrlEncodedClaims := parts[1]
	// TODO check if base64UrlEncodedHeader & base64UrlEncodedClaims are proper base64 URL encoded strings?

	header, err := jws.DecodeJWSHeader(base64UrlEncodedHeader)
	if err != nil {
		// TODO handle error
	}

	claims, err := jwt.DecodeJWTClaims(base64UrlEncodedClaims)
	if err != nil {
		// TODO handle error
	}

	return JWT{Header: header, Claims: claims}, nil
}
```

@mistermoe what do you think of that idea ☝️ We can open a ticket & copy/paste this in if we like it.
