### PR TITLE
Add Header.Type Parameter

### DIFF
--- a/jws/jws.go
+++ b/jws/jws.go
@@ -26,8 +26,10 @@ type Header struct {
 	//
 	// [Specification]: https://datatracker.ietf.org/doc/html/rfc7515#section-4.1.1
 	ALG string `json:"alg,omitempty"`
-	// Key ID Header Parameter
+	// Key ID Header Parameter https://datatracker.ietf.org/doc/html/rfc7515#section-4.1.4
 	KID string `json:"kid,omitempty"`
+	// Type Header Parameter https://datatracker.ietf.org/doc/html/rfc7515#section-4.1.9
+	Type string `json:"typ,omitempty"`
 }
 
 type JWSPayload any


### PR DESCRIPTION
Originally motivated because [`typ` is a required JOSE header parameter in OID4VCI](https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#section-7.2.1.1)

Also added links to relevant JWS spec doc