### PR TITLE
Add JWA to the JWK when it's created or parsed from bytes

### DIFF
--- a/crypto/dsa/ecdsa/secp256k1.go
+++ b/crypto/dsa/ecdsa/secp256k1.go
@@ -28,6 +28,7 @@ func SECP256K1GeneratePrivateKey() (jwk.JWK, error) {
 	yBytes := pubKey.Y().Bytes()
 
 	privateKey := jwk.JWK{
+		ALG: SECP256K1JWA,
 		KTY: KeyType,
 		CRV: SECP256K1JWACurve,
 		D:   base64.RawURLEncoding.EncodeToString(dBytes[:]),
@@ -95,6 +96,7 @@ func SECP256K1BytesToPublicKey(input []byte) (jwk.JWK, error) {
 	}
 
 	return jwk.JWK{
+		ALG: SECP256K1JWA,
 		KTY: KeyType,
 		CRV: SECP256K1JWACurve,
 		X:   base64.RawURLEncoding.EncodeToString(pubKey.X().Bytes()),

--- a/crypto/dsa/eddsa/ed25519.go
+++ b/crypto/dsa/eddsa/ed25519.go
@@ -21,6 +21,7 @@ func ED25519GeneratePrivateKey() (jwk.JWK, error) {
 	}
 
 	privKeyJwk := jwk.JWK{
+		ALG: JWA,
 		KTY: KeyType,
 		CRV: ED25519JWACurve,
 		D:   base64.RawURLEncoding.EncodeToString(privateKey),
@@ -56,6 +57,7 @@ func ED25519BytesToPublicKey(input []byte) (jwk.JWK, error) {
 	}
 
 	return jwk.JWK{
+		ALG: JWA,
 		KTY: KeyType,
 		CRV: ED25519JWACurve,
 		X:   base64.RawURLEncoding.EncodeToString(input),


### PR DESCRIPTION
taking the following DID doc as an example:
```
{
		"id": "did:dht:cwxob5rbhhu3z9x3gfqy6cthqgm6ngrh4k8s615n7pw11czoq4fy",
		"verificationMethod": [
		{
			"id": "did:dht:cwxob5rbhhu3z9x3gfqy6cthqgm6ngrh4k8s615n7pw11czoq4fy#0",
			"type": "JsonWebKey2020",
			"controller": "did:dht:cwxob5rbhhu3z9x3gfqy6cthqgm6ngrh4k8s615n7pw11czoq4fy",
			"publicKeyJwk": {
			"crv": "Ed25519",
			"kty": "OKP",
			"alg": "EdDSA",
			"kid": "0",
			"x": "ZR8A7IHnJ5v9-TFcDzI8cZfhGJzSj29LYutpKTLwdoo"
			}
		}
		],
		"authentication": [
		"#0"
		],
		"assertionMethod": [
		"#0"
		],
		"capabilityInvocation": [
		"#0"
		],
		"capabilityDelegation": [
		"#0"
		]
	}
```
if we do `PublicKeyToBytes` and then `BytesToPublicKey` the result for the verification method would be missing the `alg` key. it would look like
```
{
	...
	"publicKeyJwk": {
	"crv": "Ed25519",
	"kty": "OKP",
	"kid": "0",
	"x": "ZR8A7IHnJ5v9-TFcDzI8cZfhGJzSj29LYutpKTLwdoo"
	}
        ...
}
```