### PR TITLE
[WIP] DID Signer

### DIFF
--- a/dids/did/bearerdid.go
+++ b/dids/did/bearerdid.go
@@ -1,6 +1,8 @@
 package did
 
 import (
+	"fmt"
+
 	"github.com/tbd54566975/web5-go/crypto"
 	"github.com/tbd54566975/web5-go/dids/didcore"
 	"github.com/tbd54566975/web5-go/jwk"
@@ -14,6 +16,8 @@ type BearerDID struct {
 	crypto.KeyManager
 	Document didcore.Document
 }
+
+type DIDSigner func(payload []byte) ([]byte, error)
 
 // ToPortableDID exports a BearerDID to a portable format
 func (d *BearerDID) ToPortableDID() (PortableDID, error) {
@@ -45,6 +49,42 @@ func (d *BearerDID) ToPortableDID() (PortableDID, error) {
 	}
 
 	return portableDID, nil
+}
+
+// GetSigner returns a sign method that can be used to sign a payload using a key associated to the DID.
+// This function also returns the verification method needed to verify the signature.
+
+// Providing the verification method allows the caller to provide the signature's recipient
+// with a reference to the verification method needed to verify the payload. This is often done
+// by including the verification method id either alongside the signature or as part of the header
+// in the case of JSON Web Signatures.
+
+// The verifier can dereference the verification method id to obtain the public key needed to verify the signature.
+//
+// This function takes a Verification Method selector that can be used to select a specific verification method
+// from the DID Document if desired. If no selector is provided, the payload will be signed with the key associated
+// to the first verification method in the DID Document.
+//
+// The selector can either be a Verification Method ID or a Purpose. If a Purpose is provided, the first verification
+// method in the DID Document that has the provided purpose will be used to sign the payload.
+//
+// The returned signer is a function that takes a byte payload and returns a byte signature.
+func (d *BearerDID) GetSigner(selector didcore.VMSelector) (DIDSigner, didcore.VerificationMethod, error) {
+	vm, err := d.Document.SelectVerificationMethod(selector)
+	if err != nil {
+		return nil, didcore.VerificationMethod{}, err
+	}
+
+	keyAlias, err := vm.PublicKeyJwk.ComputeThumbprint()
+	if err != nil {
+		return nil, didcore.VerificationMethod{}, fmt.Errorf("failed to compute key alias: %s", err.Error())
+	}
+
+	signer := func(payload []byte) ([]byte, error) {
+		return d.Sign(keyAlias, payload)
+	}
+
+	return signer, vm, nil
 }
 
 // FromPortableDID inflates a BearerDID from a portable format.

--- a/dids/did/bearerdid.go
+++ b/dids/did/bearerdid.go
@@ -55,12 +55,12 @@ func (d *BearerDID) ToPortableDID() (PortableDID, error) {
 
 // GetSigner returns a sign method that can be used to sign a payload using a key associated to the DID.
 // This function also returns the verification method needed to verify the signature.
-
+//
 // Providing the verification method allows the caller to provide the signature's recipient
 // with a reference to the verification method needed to verify the payload. This is often done
 // by including the verification method id either alongside the signature or as part of the header
 // in the case of JSON Web Signatures.
-
+//
 // The verifier can dereference the verification method id to obtain the public key needed to verify the signature.
 //
 // This function takes a Verification Method selector that can be used to select a specific verification method

--- a/dids/did/bearerdid.go
+++ b/dids/did/bearerdid.go
@@ -17,6 +17,8 @@ type BearerDID struct {
 	Document didcore.Document
 }
 
+// DIDSigner is a function returned by GetSigner that can be used to sign a payload with a key
+// associated to a BearerDID.
 type DIDSigner func(payload []byte) ([]byte, error)
 
 // ToPortableDID exports a BearerDID to a portable format

--- a/dids/did/bearerdid_test.go
+++ b/dids/did/bearerdid_test.go
@@ -4,7 +4,9 @@ import (
 	"testing"
 
 	"github.com/alecthomas/assert/v2"
+	"github.com/tbd54566975/web5-go/crypto/dsa"
 	"github.com/tbd54566975/web5-go/dids/did"
+	"github.com/tbd54566975/web5-go/dids/didcore"
 	"github.com/tbd54566975/web5-go/dids/didjwk"
 	"github.com/tbd54566975/web5-go/jwk"
 	"github.com/tbd54566975/web5-go/jws"
@@ -42,4 +44,23 @@ func TestFromPortableDID(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal[string](t, compactJWS, compactJWSAgane, "failed to produce same signature with imported did")
+}
+
+func TestGetSigner(t *testing.T) {
+	bearerDID, err := didjwk.Create()
+	assert.NoError(t, err)
+
+	sign, vm, err := bearerDID.GetSigner(nil)
+	assert.NoError(t, err)
+
+	assert.NotEqual(t, vm, didcore.VerificationMethod{}, "expected verification method to not be empty")
+
+	payload := []byte("hi")
+	signature, err := sign(payload)
+	assert.NoError(t, err)
+
+	legit, err := dsa.Verify(payload, signature, *vm.PublicKeyJwk)
+	assert.NoError(t, err)
+
+	assert.True(t, legit, "expected signature to be valid")
 }

--- a/dids/didcore/document.go
+++ b/dids/didcore/document.go
@@ -130,7 +130,7 @@ func (i ID) selector() {}
 // is returned
 //
 // The selector can either be an ID, Purpose, or nil. If a Purpose is provided, the first verification
-// method in the DID Document that has the provided purpose will be used to sign the payload.
+// method in the DID Document that has the provided purpose will be returned.
 func (d *Document) SelectVerificationMethod(selector VMSelector) (VerificationMethod, error) {
 	if len(d.VerificationMethod) == 0 {
 		return VerificationMethod{}, fmt.Errorf("no verification methods found")

--- a/dids/didcore/document.go
+++ b/dids/didcore/document.go
@@ -126,7 +126,7 @@ type ID string
 func (i ID) selector() {}
 
 // SelectVerificationMethod takes a selector that can be used to select a specific verification
-// method from the DID Document. If no selector is provided, the first verification method
+// method from the DID Document. If a nil selector is provided, the first verification method
 // is returned
 //
 // The selector can either be an ID or a Purpose. If a Purpose is provided, the first verification

--- a/dids/didcore/document.go
+++ b/dids/didcore/document.go
@@ -6,6 +6,14 @@ import (
 	"github.com/tbd54566975/web5-go/jwk"
 )
 
+const (
+	PurposeAssertion            Purpose = "assertionMethod"
+	PurposeAuthentication       Purpose = "authentication"
+	PurposeCapabilityDelegation Purpose = "capabilityDelegation"
+	PurposeCapabilityInvocation Purpose = "capabilityInvocation"
+	PurposeKeyAgreement         Purpose = "keyAgreement"
+)
+
 // Document represents a set of data describing the DID subject including mechanisms such as:
 //   - cryptographic public keys - used to authenticate itself and prove
 //     association with the DID
@@ -64,12 +72,12 @@ type Document struct {
 }
 
 type addVMOptions struct {
-	purposes []string
+	purposes []Purpose
 }
 
 type AddVMOption func(o *addVMOptions)
 
-func Purposes(p ...string) AddVMOption {
+func Purposes(p ...Purpose) AddVMOption {
 	return func(o *addVMOptions) {
 		o.purposes = p
 	}
@@ -78,7 +86,7 @@ func Purposes(p ...string) AddVMOption {
 // AddVerificationMethod adds a verification method to the document. if Purposes are provided,
 // the verification method's ID will be added to the corresponding list of purposes.
 func (d *Document) AddVerificationMethod(method VerificationMethod, opts ...AddVMOption) {
-	o := &addVMOptions{purposes: []string{}}
+	o := &addVMOptions{purposes: []Purpose{}}
 	for _, opt := range opts {
 		opt(o)
 	}
@@ -87,15 +95,15 @@ func (d *Document) AddVerificationMethod(method VerificationMethod, opts ...AddV
 
 	for _, p := range o.purposes {
 		switch p {
-		case "assertionMethod":
+		case PurposeAssertion:
 			d.AssertionMethod = append(d.AssertionMethod, method.ID)
-		case "authentication":
+		case PurposeAuthentication:
 			d.Authentication = append(d.Authentication, method.ID)
-		case "keyAgreement":
+		case PurposeKeyAgreement:
 			d.KeyAgreement = append(d.KeyAgreement, method.ID)
-		case "capabilityDelegation":
+		case PurposeCapabilityDelegation:
 			d.CapabilityDelegation = append(d.CapabilityDelegation, method.ID)
-		case "capabilityInvocation":
+		case PurposeCapabilityInvocation:
 			d.CapabilityInvocation = append(d.CapabilityInvocation, method.ID)
 		}
 	}
@@ -136,31 +144,31 @@ func (d *Document) SelectVerificationMethod(selector VMSelector) (VerificationMe
 	switch s := selector.(type) {
 	case Purpose:
 		switch purpose := Purpose(s); purpose {
-		case "assertionMethod":
+		case PurposeAssertion:
 			if len(d.AssertionMethod) == 0 {
 				return VerificationMethod{}, fmt.Errorf("no verification method found for purpose: %s", purpose)
 			}
 
 			vmID = d.AssertionMethod[0]
-		case "authentication":
+		case PurposeAuthentication:
 			if len(d.Authentication) == 0 {
 				return VerificationMethod{}, fmt.Errorf("no %s verification method found", s)
 			}
 
 			vmID = d.Authentication[0]
-		case "capabilityDelegation":
+		case PurposeCapabilityDelegation:
 			if len(d.CapabilityDelegation) == 0 {
 				return VerificationMethod{}, fmt.Errorf("no %s verification method found", s)
 			}
 
 			vmID = d.CapabilityDelegation[0]
-		case "capabilityInvocation":
+		case PurposeCapabilityInvocation:
 			if len(d.CapabilityInvocation) == 0 {
 				return VerificationMethod{}, fmt.Errorf("no %s verification method found", s)
 			}
 
 			vmID = d.CapabilityInvocation[0]
-		case "keyAgreement":
+		case PurposeKeyAgreement:
 			if len(d.KeyAgreement) == 0 {
 				return VerificationMethod{}, fmt.Errorf("no %s verification method found", s)
 			}

--- a/dids/didcore/document.go
+++ b/dids/didcore/document.go
@@ -117,8 +117,8 @@ type ID string
 
 func (i ID) selector() {}
 
-// SelectVerificationMethod takes a Verification Method selector that can be used to select a specific
-// verification method from the DID Document if desired. If no selector is provided, the first verification method
+// SelectVerificationMethod takes a selector that can be used to select a specific verification
+// method from the DID Document. If no selector is provided, the first verification method
 // is returned
 //
 // The selector can either be an ID or a Purpose. If a Purpose is provided, the first verification

--- a/dids/didcore/document.go
+++ b/dids/didcore/document.go
@@ -129,7 +129,7 @@ func (i ID) selector() {}
 // method from the DID Document. If a nil selector is provided, the first verification method
 // is returned
 //
-// The selector can either be an ID or a Purpose. If a Purpose is provided, the first verification
+// The selector can either be an ID, Purpose, or nil. If a Purpose is provided, the first verification
 // method in the DID Document that has the provided purpose will be used to sign the payload.
 func (d *Document) SelectVerificationMethod(selector VMSelector) (VerificationMethod, error) {
 	if len(d.VerificationMethod) == 0 {

--- a/dids/didcore/document_test.go
+++ b/dids/didcore/document_test.go
@@ -1,26 +1,43 @@
-package didcore
+package didcore_test
 
 import (
 	"testing"
 
 	"github.com/alecthomas/assert/v2"
+	"github.com/tbd54566975/web5-go/dids/didcore"
 )
 
 func TestAddVerificationMethod(t *testing.T) {
-	doc := Document{
+	doc := didcore.Document{
 		Context: "https://www.w3.org/ns/did/v1",
 		ID:      "did:example:123456789abcdefghi",
 	}
 
-	vm := VerificationMethod{
+	vm := didcore.VerificationMethod{
 		ID:         "did:example:123456789abcdefghi#keys-1",
 		Type:       "Ed25519VerificationKey2018",
 		Controller: "did:example:123456789abcdefghi",
 	}
 
-	doc.AddVerificationMethod(vm, Purposes("authentication"))
+	doc.AddVerificationMethod(vm, didcore.Purposes("authentication"))
 
 	assert.Equal(t, 1, len(doc.VerificationMethod))
 	assert.Equal(t, 1, len(doc.Authentication))
 	assert.Equal(t, vm.ID, doc.Authentication[0])
+}
+
+func TestWoo(t *testing.T) {
+	doc := didcore.Document{
+		ID: "did:example:123456789abcdefghi",
+	}
+
+	doc.AddVerificationMethod(didcore.VerificationMethod{
+		ID:         "did:example:123456789abcdefghi#keys-1",
+		Type:       "Ed25519VerificationKey2018",
+		Controller: "did:example:123456789abcdefghi",
+	}, didcore.Purposes("authentication"))
+
+	vm, err := doc.SelectVerificationMethod(didcore.Purpose("authentication"))
+	assert.NoError(t, err)
+	assert.Equal(t, "did:example:123456789abcdefghi#keys-1", vm.ID)
 }

--- a/dids/diddht/diddht.go
+++ b/dids/diddht/diddht.go
@@ -25,12 +25,12 @@ var txtEntityNames = map[string]struct{}{
 	"del":  {},
 }
 
-var relationshipDNStoDID = map[string]string{
-	"auth": "authentication",
-	"asm":  "assertionMethod",
-	"agm":  "keyAgreement",
-	"inv":  "capabilityInvocation",
-	"del":  "capabilityDelegation",
+var relationshipDNStoDID = map[string]didcore.Purpose{
+	"auth": didcore.PurposeAuthentication,
+	"asm":  didcore.PurposeAssertion,
+	"agm":  didcore.PurposeKeyAgreement,
+	"inv":  didcore.PurposeKeyAgreement,
+	"del":  didcore.PurposeCapabilityDelegation,
 }
 
 var keyTypes = map[string]string{
@@ -84,7 +84,7 @@ func (rec *dhtDIDRecord) DIDDocument(didURI string) *didcore.Document {
 				continue
 			}
 
-			opts := []string{}
+			opts := []didcore.Purpose{}
 			for _, r := range relationships {
 				if o, ok := relationshipDNStoDID[r]; ok {
 					opts = append(opts, o)

--- a/dids/didweb/didweb.go
+++ b/dids/didweb/didweb.go
@@ -28,7 +28,7 @@ type createOptions struct {
 // privateKeyOption is a struct to hold options for creating a new private key.
 type privateKeyOption struct {
 	algorithmID string
-	purposes    []string
+	purposes    []didcore.Purpose
 }
 
 // Service is used to add a service to the DID being created with the [Create] function.
@@ -56,7 +56,7 @@ func Service(id string, svcType string, endpoint string) CreateOption {
 // PrivateKey is used to add a private key to the DID being created with the [Create] function.
 // Each PrivateKey provided will be used to generate a private key in the key manager and then
 // added to the DID Document as a VerificationMethod.
-func PrivateKey(algorithmID string, purposes ...string) CreateOption {
+func PrivateKey(algorithmID string, purposes ...didcore.Purpose) CreateOption {
 	return func(o *createOptions) {
 		keyOpts := privateKeyOption{algorithmID: algorithmID, purposes: purposes}
 

--- a/jws/jws_test.go
+++ b/jws/jws_test.go
@@ -26,6 +26,24 @@ func TestSign(t *testing.T) {
 	assert.Equal(t, 3, len(parts), "expected 3 parts in compact JWS")
 }
 
+func TestSign_Detached(t *testing.T) {
+	did, err := didjwk.Create()
+	assert.NoError(t, err)
+
+	payload := map[string]interface{}{"hello": "world"}
+
+	compactJWS, err := jws.Sign(payload, did, jws.DetachedPayload(true))
+	assert.NoError(t, err)
+
+	assert.True(t, compactJWS != "", "expected signature to be non-empty")
+
+	parts := strings.Split(compactJWS, ".")
+	assert.Equal(t, 3, len(parts), "expected 3 parts in compact JWS")
+
+	assert.Equal(t, parts[1], "", "expected empty payload")
+
+}
+
 func TestVerify_bad(t *testing.T) {
 	badHeader := base64.RawURLEncoding.EncodeToString([]byte("hehe"))
 	okHeader := jws.Header{ALG: "ES256K", KID: "did:web:abc#key-1"}.Base64UrlEncode()


### PR DESCRIPTION
> [!WARNING]
> 🚧 WIP 🚧 


## Goals
* From a caller's perspective, simplify the steps needed to sign a payload with a key associated to a DID as much as possible.
* Reduce the amount of did-specific boilerplate code needed to produce any type of signature using a `BearerDID`. currently, [here](https://github.com/TBD54566975/web5-go/blob/main/jws/jws.go#L97-L126) are all the steps needed _everywhere_ a `BearerDID` is used to sign something. This requires an implementer's neckbeard to be of significant length. certainly long enough to cause undesired chafing.
    *  This problem actually exists in all of our SDKs at the moment and acts as a significant barrier for implementers attempting to implement functionality that requires signing something with a DID (e.g. tbdex messages)

> [!IMPORTANT]
> the changes in this PR provide quite a bit more optionality and defensive checks (specifically wrt verification method selection) than what's currently on main 

## Current Usage

### No Options (aka default signer)
```go
func main() {
    bearerDID, err := didjwk.Create()
    if err != nil {
        panic(err)
    }

    sign, verificationMethod, err := bearerDID.GetSigner(nil)
    if err != nil {
        panic(err)
    }

    payload := []byte("hi")
    signature, err := sign(payload)
    if err != nil {
        panic(err)
    }

    fmt.Printf("signature: %s\n", hex.EncodeToString(signature))

    legit, err := dsa.Verify(payload, signature, *verificationMethod.PublicKeyJwk)
    if err != nil {
        panic(err)
    }

    if !legit {
        panic("expected signature to be valid")
    }
}
```

### With Options (signer using a key with a specific purpose)
```go
func main() {
    bearerDID, err := didjwk.Create()
    if err != nil {
        panic(err)
    }

    sign, _, err := bearerDID.GetSigner(didcore.Purpose("authentication"))
    if err != nil {
        panic(err)
    }

    payload := []byte("hi")
    signature, err := sign(payload)
    if err != nil {
        panic(err)
    }

    fmt.Printf("signature: %s\n", hex.EncodeToString(signature))
}
```

## `BearerDID.GetSigner()` Explanation
`GetSigner` returns a `sign` method that can be used to sign a payload using a key associated to the `BearerDID`. This function also returns the verification method needed to _verify_ the signature.

Returning the verification method allows the caller to provide the signature's recipient with a _reference_ to the verification method needed to verify the payload. This is often done by including the verification method id either alongside the signature or as part of the header in the case of JSON Web Signatures.

The verifier can dereference the verification method id to obtain the public key needed to verify the signature. This function _optionally_ takes a Verification Method selector that can be used to select a specific verification method from the DID Document if desired. If no selector is provided, the payload will be signed with the key associated to the first verification method in the DID Document.

The selector can either be a Verification Method ID or a Purpose. If a Purpose is provided, the first verification method in the DID Document that has the provided purpose will be used to sign the payload.

The returned signer is a function that takes a byte payload and returns a byte signature.

## Concerns
The potential complexity introduced may outweigh the cognitive overhead required to maintain the code added in this PR.

## Benefits
* DID specific code is isolated to the `did` package instead of spilling out into many other packages. this makes changing key selection strategies easier because we can change them in 1 place vs. 3 or 4 across more than 1 repo
* it's kinda cool that in 15ish lines of code you can sign a payload using a key stored in an HSM based KMS