### PR TITLE
Add parameterization for jws.Sign() for 'typ' header

### DIFF
--- a/jws/jws.go
+++ b/jws/jws.go
@@ -36,8 +36,7 @@ type JWSPayload any
 
 // Base64UrlEncode returns the base64url encoded header.
 func (j Header) Base64UrlEncode() (string, error) {
-	jsonHeader := map[string]string{"alg": j.ALG, "kid": j.KID}
-	bytes, err := json.Marshal(jsonHeader)
+	bytes, err := json.Marshal(j)
 	if err != nil {
 		return "", err
 	}
@@ -65,6 +64,7 @@ func DecodeHeader(base64UrlEncodedHeader string) (Header, error) {
 type signOpts struct {
 	selector didcore.VMSelector
 	detached bool
+	typ      string
 }
 
 // SignOpts is a type that represents an option that can be passed to [github.com/tbd54566975/web5-go/jws.Sign].
@@ -97,6 +97,14 @@ func VMSelector(selector didcore.VMSelector) SignOpts {
 func DetachedPayload(detached bool) SignOpts {
 	return func(opts *signOpts) {
 		opts.detached = detached
+	}
+}
+
+// Purpose is an option that can be passed to [github.com/tbd54566975/web5-go/jws.Sign].
+// It is used to select the appropriate key to sign with
+func Type(typ string) SignOpts {
+	return func(opts *signOpts) {
+		opts.typ = typ
 	}
 }
 

--- a/jws/jws.go
+++ b/jws/jws.go
@@ -29,7 +29,7 @@ type Header struct {
 	// Key ID Header Parameter https://datatracker.ietf.org/doc/html/rfc7515#section-4.1.4
 	KID string `json:"kid,omitempty"`
 	// Type Header Parameter https://datatracker.ietf.org/doc/html/rfc7515#section-4.1.9
-	Type string `json:"typ,omitempty"`
+	TYP string `json:"typ,omitempty"`
 }
 
 type JWSPayload any
@@ -102,7 +102,7 @@ func DetachedPayload(detached bool) SignOpts {
 
 // Purpose is an option that can be passed to [github.com/tbd54566975/web5-go/jws.Sign].
 // It is used to select the appropriate key to sign with
-func Type(typ string) SignOpts {
+func TYP(typ string) SignOpts {
 	return func(opts *signOpts) {
 		opts.typ = typ
 	}
@@ -128,7 +128,7 @@ func Sign(payload JWSPayload, did did.BearerDID, opts ...SignOpts) (string, erro
 	}
 
 	keyID := did.Document.GetAbsoluteResourceID(verificationMethod.ID)
-	header := Header{ALG: jwa, KID: keyID}
+	header := Header{ALG: jwa, KID: keyID, TYP: o.typ}
 	base64UrlEncodedHeader, err := header.Base64UrlEncode()
 	if err != nil {
 		return "", fmt.Errorf("failed to base64 url encode header: %s", err.Error())

--- a/jws/jws.go
+++ b/jws/jws.go
@@ -102,7 +102,7 @@ func DetachedPayload(detached bool) SignOpts {
 
 // Purpose is an option that can be passed to [github.com/tbd54566975/web5-go/jws.Sign].
 // It is used to select the appropriate key to sign with
-func TYP(typ string) SignOpts {
+func Type(typ string) SignOpts {
 	return func(opts *signOpts) {
 		opts.typ = typ
 	}

--- a/jws/jws_test.go
+++ b/jws/jws_test.go
@@ -52,6 +52,24 @@ func TestSign_Detached(t *testing.T) {
 
 }
 
+func TestSign_CustomType(t *testing.T) {
+	did, err := didjwk.Create()
+	assert.NoError(t, err)
+
+	payload := map[string]interface{}{"hello": "world"}
+	customType := "openid4vci-proof+jwt"
+
+	compactJWS, err := jws.Sign(payload, did, jws.Type(customType))
+	assert.NoError(t, err)
+
+	parts := strings.Split(compactJWS, ".")
+	encodedHeader := parts[0]
+	header, err := jws.DecodeHeader(encodedHeader)
+	assert.NoError(t, err)
+
+	assert.Equal(t, customType, header.Type)
+}
+
 func TestVerify_bad(t *testing.T) {
 	badHeader := base64.RawURLEncoding.EncodeToString([]byte("hehe"))
 	okHeader, err := jws.Header{ALG: "ES256K", KID: "did:web:abc#key-1"}.Base64UrlEncode()

--- a/jws/jws_test.go
+++ b/jws/jws_test.go
@@ -59,7 +59,7 @@ func TestSign_CustomType(t *testing.T) {
 	payload := map[string]interface{}{"hello": "world"}
 	customType := "openid4vci-proof+jwt"
 
-	compactJWS, err := jws.Sign(payload, did, jws.Type(customType))
+	compactJWS, err := jws.Sign(payload, did, jws.TYP(customType))
 	assert.NoError(t, err)
 
 	parts := strings.Split(compactJWS, ".")
@@ -67,7 +67,7 @@ func TestSign_CustomType(t *testing.T) {
 	header, err := jws.DecodeHeader(encodedHeader)
 	assert.NoError(t, err)
 
-	assert.Equal(t, customType, header.Type)
+	assert.Equal(t, customType, header.TYP)
 }
 
 func TestVerify_bad(t *testing.T) {

--- a/jws/jws_test.go
+++ b/jws/jws_test.go
@@ -59,7 +59,7 @@ func TestSign_CustomType(t *testing.T) {
 	payload := map[string]interface{}{"hello": "world"}
 	customType := "openid4vci-proof+jwt"
 
-	compactJWS, err := jws.Sign(payload, did, jws.TYP(customType))
+	compactJWS, err := jws.Sign(payload, did, jws.Type(customType))
 	assert.NoError(t, err)
 
 	parts := strings.Split(compactJWS, ".")


### PR DESCRIPTION
@mistermoe I whipped this together kind of in a flash so lmk if I'm totally off base

Originally motivated by the fact that the proof JWT in OID4VCI needs to be [explicitly typed](https://www.rfc-editor.org/rfc/rfc8725.html#section-3.11) with [the value `openid4vci-proof+jwt`](https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#section-7.2.1.1-2.1.2.2)

The premise here being, [we added a](https://github.com/TBD54566975/web5-go/pull/26) `Type` property to the `jws.Header` type, but the call to `jws.Sign()` builds the `Header` dynamically from the relative material from the DID Document... a few thoughts...

- I was consistent in our variadic function approach
- I wrote a test, albeit our test coverage is incomplete in the `jws` module, but it's good enough
- maybe we should rename `jws.Sign()` to something like `jws.DIDSign()` which builds the header from the given DID document and then we keep a function named `jws.Sign()` which takes in a header a payload and just does the signing (`jws.DIDsign()` would call `jws.Sign()`)

Idk I'm a little out of my depth here so feel free to propose an entirely different direction