### PR TITLE
Add support for developing on Replit

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,14 @@
+run = ["just", "test"]
+
+modules = ["go-1.21:v2-20231201-3b22c78"]
+
+[nix]
+channel = "stable-23_05"
+
+[gitHubImport]
+requiredFiles = [".replit"]
+
+[deployment]
+run = ["sh", "-c", "just test"]
+ignorePorts = false
+deploymentTarget = "gce"

--- a/README.md
+++ b/README.md
@@ -66,3 +66,5 @@ This repo uses [`just`](https://github.com/casey/just) as a command runner. Belo
 
 ### Contributing
 Each package's README contains in-depth information about the package's structure and suggestions on how add features specific to that package
+
+You can develop web5-go on [Replit](https://replit.com/github/TBD54566975/web5-go).

--- a/replit.nix
+++ b/replit.nix
@@ -1,0 +1,5 @@
+{ pkgs }: {
+  deps = [
+    pkgs.just
+  ];
+}


### PR DESCRIPTION
Hey! I wanted to see if we could get this repo working on [Replit](https://replit.com).

I added a couple config files to properly setup LSP and provide `go` and `just` in the environment and I wired up the Run button to run the full test suite. You can try this out by forking my repl here: https://replit.com/@ConnorBrewster/web5-go or, if this is merged, you can import this repo directly into a new repl and start coding right away.