### PR TITLE
JWS header `kid` fix

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -10,7 +10,7 @@
 
 # These owners will be the default owners for everything in the repo.
 
-* @alecthomas @mihai-chiorean @mistermoe @wesbillman
+* @alecthomas @mihai-chiorean @mistermoe @tomdaffurn @wesbillman
 
 # -----------------------------------------------
 # BELOW THIS LINE ARE TEMPLATES, UNUSED

--- a/dids/didcore/document.go
+++ b/dids/didcore/document.go
@@ -194,6 +194,17 @@ func (d *Document) AddService(service *Service) {
 	d.Service = append(d.Service, service)
 }
 
+// GetAbsoluteResourceID returns a fully qualified ID for a document resource (e.g. service, verification method)
+// Document Resource IDs are allowed to be relative DID URLs as a means to reduce storage size of DID Documents.
+// More info here: https://www.w3.org/TR/did-core/#relative-did-urls
+func (d *Document) GetAbsoluteResourceID(id string) string {
+	if id[0] == '#' {
+		return d.ID + id
+	} else {
+		return id
+	}
+}
+
 // DocumentMetadata contains metadata about the DID Document
 // This metadata typically does not change between invocations of
 // the resolve and resolveRepresentation functions unless the DID document

--- a/jws/jws.go
+++ b/jws/jws.go
@@ -116,15 +116,7 @@ func Sign(payload JWSPayload, did did.BearerDID, opts ...SignOpts) (string, erro
 		return "", fmt.Errorf("failed to determine alg: %s", err.Error())
 	}
 
-	// TODO: consider putting this logic into did.getSigner and returning just the verification method id instead of the
-	//       entire verification method. this is very esoteric did spec detail
-	var keyID string
-	if verificationMethod.ID[0] == '#' {
-		keyID = did.URI + verificationMethod.ID
-	} else {
-		keyID = verificationMethod.ID
-	}
-
+	keyID := did.Document.GetAbsoluteResourceID(verificationMethod.ID)
 	header := Header{ALG: jwa, KID: keyID}
 	base64UrlEncodedHeader := header.Base64UrlEncode()
 

--- a/jws/jws.go
+++ b/jws/jws.go
@@ -116,7 +116,16 @@ func Sign(payload JWSPayload, did did.BearerDID, opts ...SignOpts) (string, erro
 		return "", fmt.Errorf("failed to determine alg: %s", err.Error())
 	}
 
-	header := Header{ALG: jwa, KID: verificationMethod.ID}
+	// TODO: consider putting this logic into did.getSigner and returning just the verification method id instead of the
+	//       entire verification method. this is very esoteric did spec detail
+	var keyID string
+	if verificationMethod.ID[0] == '#' {
+		keyID = did.URI + verificationMethod.ID
+	} else {
+		keyID = verificationMethod.ID
+	}
+
+	header := Header{ALG: jwa, KID: keyID}
 	base64UrlEncodedHeader := header.Base64UrlEncode()
 
 	payloadBytes, err := json.Marshal(payload)

--- a/jws/jws_test.go
+++ b/jws/jws_test.go
@@ -9,11 +9,12 @@ import (
 
 	"github.com/alecthomas/assert/v2"
 	"github.com/tbd54566975/web5-go/dids/didjwk"
+	"github.com/tbd54566975/web5-go/dids/didweb"
 	"github.com/tbd54566975/web5-go/jws"
 )
 
 func TestSign(t *testing.T) {
-	did, err := didjwk.Create()
+	did, err := didweb.Create("localhost:8080")
 	assert.NoError(t, err)
 
 	payload := map[string]interface{}{"hello": "world"}
@@ -24,6 +25,13 @@ func TestSign(t *testing.T) {
 
 	parts := strings.Split(compactJWS, ".")
 	assert.Equal(t, 3, len(parts), "expected 3 parts in compact JWS")
+
+	header, err := jws.DecodeHeader(parts[0])
+	assert.NoError(t, err)
+
+	assert.NotZero(t, header.ALG, "expected alg to be set in jws header")
+	assert.NotZero(t, header.KID, "expected kid to be set in jws header")
+	assert.Contains(t, header.KID, did.URI, "expected kid to match did key id")
 }
 
 func TestSign_Detached(t *testing.T) {


### PR DESCRIPTION
ensures absolute verification method id is set as value of jws kid. ran into this issue while working on something else in pfi repo