### PR TITLE
Handle error in jws.Base64UrlEncode()

### DIFF
--- a/jws/jws_test.go
+++ b/jws/jws_test.go
@@ -54,7 +54,8 @@ func TestSign_Detached(t *testing.T) {
 
 func TestVerify_bad(t *testing.T) {
 	badHeader := base64.RawURLEncoding.EncodeToString([]byte("hehe"))
-	okHeader := jws.Header{ALG: "ES256K", KID: "did:web:abc#key-1"}.Base64UrlEncode()
+	okHeader, err := jws.Header{ALG: "ES256K", KID: "did:web:abc#key-1"}.Base64UrlEncode()
+	assert.NoError(t, err)
 
 	okPayloadJSON := map[string]interface{}{"hello": "world"}
 	okPayloadBytes, _ := json.Marshal(okPayloadJSON)

--- a/jwt/jwt_test.go
+++ b/jwt/jwt_test.go
@@ -81,7 +81,9 @@ func TestVerify(t *testing.T) {
 }
 
 func TestVerify_BadClaims(t *testing.T) {
-	okHeader := jws.Header{ALG: "ES256K", KID: "did:web:abc#key-1"}.Base64UrlEncode()
+	okHeader, err := jws.Header{ALG: "ES256K", KID: "did:web:abc#key-1"}.Base64UrlEncode()
+	assert.NoError(t, err)
+	
 	input := fmt.Sprintf("%s.%s.%s", okHeader, "hehe", "hehe")
 
 	verified, err := jwt.Verify(input)


### PR DESCRIPTION
Originally called out here https://github.com/TBD54566975/web5-go/pull/36/files/9649d3be37864c2c7abfdecaf0f14dc4964053d5#r1483659387