### PR TITLE
`JW*` Decode

### DIFF
--- a/jws/jws.go
+++ b/jws/jws.go
@@ -25,18 +25,18 @@ func Decode(jws string) (Decoded, error) {
 
 	payloadBytes, err := base64.RawURLEncoding.DecodeString(parts[1])
 	if err != nil {
-		return Decoded{}, fmt.Errorf("malformed JWS. Failed to decode payload: %s", err.Error())
+		return Decoded{}, fmt.Errorf("malformed JWS. Failed to decode payload: %w", err)
 	}
 
 	var payload Payload
 	err = json.Unmarshal(payloadBytes, &payload)
 	if err != nil {
-		return Decoded{}, fmt.Errorf("malformed JWS. Failed to unmarshal payload: %s", err.Error())
+		return Decoded{}, fmt.Errorf("malformed JWS. Failed to unmarshal payload: %w", err)
 	}
 
 	signature, err := DecodeSignature(parts[2])
 	if err != nil {
-		return Decoded{}, fmt.Errorf("malformed JWS. Failed to decode signature: %s", err.Error())
+		return Decoded{}, fmt.Errorf("malformed JWS. Failed to decode signature: %w", err)
 	}
 
 	return Decoded{
@@ -131,24 +131,24 @@ func Sign(payload Payload, did did.BearerDID, opts ...SignOpt) (string, error) {
 
 	sign, verificationMethod, err := did.GetSigner(o.selector)
 	if err != nil {
-		return "", fmt.Errorf("failed to get signer: %s", err.Error())
+		return "", fmt.Errorf("failed to get signer: %w", err)
 	}
 
 	jwa, err := dsa.GetJWA(*verificationMethod.PublicKeyJwk)
 	if err != nil {
-		return "", fmt.Errorf("failed to determine alg: %s", err.Error())
+		return "", fmt.Errorf("failed to determine alg: %w", err)
 	}
 
 	keyID := did.Document.GetAbsoluteResourceID(verificationMethod.ID)
 	header := Header{ALG: jwa, KID: keyID, TYP: o.typ}
 	base64UrlEncodedHeader, err := header.Encode()
 	if err != nil {
-		return "", fmt.Errorf("failed to base64 url encode header: %s", err.Error())
+		return "", fmt.Errorf("failed to base64 url encode header: %w", err)
 	}
 
 	payloadBytes, err := json.Marshal(payload)
 	if err != nil {
-		return "", fmt.Errorf("failed to marshal payload: %s", err.Error())
+		return "", fmt.Errorf("failed to marshal payload: %w", err)
 	}
 
 	base64UrlEncodedPayload := base64.RawURLEncoding.EncodeToString(payloadBytes)
@@ -158,7 +158,7 @@ func Sign(payload Payload, did did.BearerDID, opts ...SignOpt) (string, error) {
 
 	signature, err := sign(toSignBytes)
 	if err != nil {
-		return "", fmt.Errorf("failed to compute signature: %s", err.Error())
+		return "", fmt.Errorf("failed to compute signature: %w", err)
 	}
 
 	base64UrlEncodedSignature := base64.RawURLEncoding.EncodeToString(signature)

--- a/jws/jws.go
+++ b/jws/jws.go
@@ -18,14 +18,12 @@ func Decode(jws string) (Decoded, error) {
 		return Decoded{}, fmt.Errorf("malformed JWS. Expected 3 parts, got %d", len(parts))
 	}
 
-	base64UrlEncodedHeader := parts[0]
-	header, err := DecodeHeader(base64UrlEncodedHeader)
+	header, err := DecodeHeader(parts[0])
 	if err != nil {
 		return Decoded{}, fmt.Errorf("malformed JWS. Failed to decode header: %w", err)
 	}
 
-	base64UrlEncodedPayload := parts[1]
-	payloadBytes, err := base64.RawURLEncoding.DecodeString(base64UrlEncodedPayload)
+	payloadBytes, err := base64.RawURLEncoding.DecodeString(parts[1])
 	if err != nil {
 		return Decoded{}, fmt.Errorf("malformed JWS. Failed to decode payload: %s", err.Error())
 	}
@@ -36,8 +34,7 @@ func Decode(jws string) (Decoded, error) {
 		return Decoded{}, fmt.Errorf("malformed JWS. Failed to unmarshal payload: %s", err.Error())
 	}
 
-	base64UrlEncodedSignature := parts[2]
-	signature, err := DecodeSignature(base64UrlEncodedSignature)
+	signature, err := DecodeSignature(parts[2])
 	if err != nil {
 		return Decoded{}, fmt.Errorf("malformed JWS. Failed to decode signature: %s", err.Error())
 	}
@@ -144,7 +141,7 @@ func Sign(payload Payload, did did.BearerDID, opts ...SignOpt) (string, error) {
 
 	keyID := did.Document.GetAbsoluteResourceID(verificationMethod.ID)
 	header := Header{ALG: jwa, KID: keyID, TYP: o.typ}
-	base64UrlEncodedHeader, err := header.Base64UrlEncode()
+	base64UrlEncodedHeader, err := header.Encode()
 	if err != nil {
 		return "", fmt.Errorf("failed to base64 url encode header: %s", err.Error())
 	}
@@ -250,8 +247,8 @@ type Header struct {
 	TYP string `json:"typ,omitempty"`
 }
 
-// Base64UrlEncode returns the base64url encoded header.
-func (j Header) Base64UrlEncode() (string, error) {
+// Encode returns the base64url encoded header.
+func (j Header) Encode() (string, error) {
 	bytes, err := json.Marshal(j)
 	if err != nil {
 		return "", err

--- a/jws/jws_test.go
+++ b/jws/jws_test.go
@@ -26,7 +26,7 @@ func TestDecode(t *testing.T) {
 
 	payload, ok := decoded.Payload.(map[string]any)
 	assert.True(t, ok)
-	assert.Equal(t, payload["hello"], "world")
+	assert.Equal(t, "world", payload["hello"])
 }
 
 func TestDecode_Bad(t *testing.T) {
@@ -81,7 +81,6 @@ func TestSign_Detached(t *testing.T) {
 	parts := strings.Split(compactJWS, ".")
 	assert.Equal(t, 3, len(parts), "expected 3 parts in compact JWS")
 	assert.Equal(t, parts[1], "", "expected empty payload")
-
 }
 
 func TestSign_CustomType(t *testing.T) {
@@ -108,7 +107,6 @@ func TestDecoded_Verify(t *testing.T) {
 
 	payloadJSON := map[string]any{"hello": "world"}
 	compactJWS, err := jws.Sign(payloadJSON, did)
-
 	assert.NoError(t, err)
 
 	decoded, err := jws.Decode(compactJWS)
@@ -124,7 +122,6 @@ func TestDecoded_Verify_Bad(t *testing.T) {
 		ALG: "ES256K",
 		KID: did.Document.VerificationMethod[0].ID,
 	}.Encode()
-
 	assert.NoError(t, err)
 
 	payloadJSON := map[string]any{"hello": "world"}

--- a/jws/jws_test.go
+++ b/jws/jws_test.go
@@ -13,6 +13,49 @@ import (
 	"github.com/tbd54566975/web5-go/jws"
 )
 
+func TestDecode(t *testing.T) {
+	did, err := didjwk.Create()
+	assert.NoError(t, err)
+
+	payloadJSON := map[string]interface{}{"hello": "world"}
+	compactJWS, err := jws.Sign(payloadJSON, did)
+	assert.NoError(t, err)
+
+	decoded, err := jws.Decode(compactJWS)
+	assert.NoError(t, err)
+
+	payload, ok := decoded.Payload.(map[string]any)
+	assert.True(t, ok)
+	assert.Equal(t, payload["hello"], "world")
+}
+
+func TestDecode_Bad(t *testing.T) {
+	badHeader := base64.RawURLEncoding.EncodeToString([]byte("hehe"))
+	okHeader, err := jws.Header{ALG: "ES256K", KID: "did:web:abc#key-1"}.Base64UrlEncode()
+	assert.NoError(t, err)
+
+	okPayloadJSON := map[string]any{"hello": "world"}
+	okPayloadBytes, _ := json.Marshal(okPayloadJSON)
+	okPayload := base64.RawURLEncoding.EncodeToString(okPayloadBytes)
+
+	badSignature := base64.RawURLEncoding.EncodeToString([]byte("hehe"))
+
+	vectors := []string{
+		"",
+		"..",
+		"a.b.c",
+		fmt.Sprintf("%s.%s.%s", badHeader, badHeader, badHeader),
+		fmt.Sprintf("%s.%s.%s", okHeader, okPayload, badSignature),
+	}
+
+	for _, vector := range vectors {
+		decoded, err := jws.Decode(vector)
+
+		assert.Error(t, err, "expected verification error. vector: %s", vector)
+		assert.Equal(t, jws.Decoded{}, decoded, "expected empty DecodedJWS")
+	}
+}
+
 func TestSign(t *testing.T) {
 	did, err := didweb.Create("localhost:8080")
 	assert.NoError(t, err)
@@ -47,7 +90,6 @@ func TestSign_Detached(t *testing.T) {
 
 	parts := strings.Split(compactJWS, ".")
 	assert.Equal(t, 3, len(parts), "expected 3 parts in compact JWS")
-
 	assert.Equal(t, parts[1], "", "expected empty payload")
 
 }
@@ -70,44 +112,50 @@ func TestSign_CustomType(t *testing.T) {
 	assert.Equal(t, customType, header.TYP)
 }
 
-func TestVerify_bad(t *testing.T) {
-	badHeader := base64.RawURLEncoding.EncodeToString([]byte("hehe"))
-	okHeader, err := jws.Header{ALG: "ES256K", KID: "did:web:abc#key-1"}.Base64UrlEncode()
-	assert.NoError(t, err)
-
-	okPayloadJSON := map[string]interface{}{"hello": "world"}
-	okPayloadBytes, _ := json.Marshal(okPayloadJSON)
-	okPayload := base64.RawURLEncoding.EncodeToString(okPayloadBytes)
-
-	badSignature := base64.RawURLEncoding.EncodeToString([]byte("hehe"))
-
-	vectors := []string{
-		"",
-		"..",
-		"a.b.c",
-		fmt.Sprintf("%s.%s.%s", badHeader, badHeader, badHeader),
-		fmt.Sprintf("%s.%s.%s", okHeader, okPayload, badSignature),
-	}
-
-	for _, vector := range vectors {
-		ok, err := jws.Verify(vector)
-
-		assert.Error(t, err, "expected verification error. vector: %s", vector)
-		assert.False(t, ok, "expected verification !ok. vector %s", vector)
-	}
-}
-
-func TestVerify_ok(t *testing.T) {
+func TestDecoded_Verify(t *testing.T) {
 	did, err := didjwk.Create()
 	assert.NoError(t, err)
 
-	payloadJSON := map[string]interface{}{"hello": "world"}
+	payloadJSON := map[string]any{"hello": "world"}
 	compactJWS, err := jws.Sign(payloadJSON, did)
 
 	assert.NoError(t, err)
 
-	ok, err := jws.Verify(compactJWS)
+	decoded, err := jws.Decode(compactJWS)
+	assert.NoError(t, err)
+	assert.NotEqual(t, jws.Decoded{}, decoded, "expected decoded to not be empty")
+}
+
+func TestDecoded_Verify_Bad(t *testing.T) {
+	did, err := didjwk.Create()
 	assert.NoError(t, err)
 
-	assert.True(t, ok, "expected verification ok")
+	header, err := jws.Header{
+		ALG: "ES256K",
+		KID: did.Document.VerificationMethod[0].ID,
+	}.Base64UrlEncode()
+
+	assert.NoError(t, err)
+
+	payloadJSON := map[string]any{"hello": "world"}
+	payloadBytes, _ := json.Marshal(payloadJSON)
+	payload := base64.RawURLEncoding.EncodeToString(payloadBytes)
+
+	compactJWS := fmt.Sprintf("%s.%s.%s", header, payload, payload)
+
+	_, err = jws.Verify(compactJWS)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "signature")
+}
+
+func TestVerify(t *testing.T) {
+	did, err := didjwk.Create()
+	assert.NoError(t, err)
+
+	payloadJSON := map[string]any{"hello": "world"}
+	compactJWS, err := jws.Sign(payloadJSON, did)
+	assert.NoError(t, err)
+
+	_, err = jws.Verify(compactJWS)
+	assert.NoError(t, err)
 }

--- a/jws/jws_test.go
+++ b/jws/jws_test.go
@@ -31,21 +31,11 @@ func TestDecode(t *testing.T) {
 
 func TestDecode_Bad(t *testing.T) {
 	badHeader := base64.RawURLEncoding.EncodeToString([]byte("hehe"))
-	okHeader, err := jws.Header{ALG: "ES256K", KID: "did:web:abc#key-1"}.Base64UrlEncode()
-	assert.NoError(t, err)
-
-	okPayloadJSON := map[string]any{"hello": "world"}
-	okPayloadBytes, _ := json.Marshal(okPayloadJSON)
-	okPayload := base64.RawURLEncoding.EncodeToString(okPayloadBytes)
-
-	badSignature := base64.RawURLEncoding.EncodeToString([]byte("hehe"))
-
 	vectors := []string{
 		"",
 		"..",
 		"a.b.c",
 		fmt.Sprintf("%s.%s.%s", badHeader, badHeader, badHeader),
-		fmt.Sprintf("%s.%s.%s", okHeader, okPayload, badSignature),
 	}
 
 	for _, vector := range vectors {
@@ -133,7 +123,7 @@ func TestDecoded_Verify_Bad(t *testing.T) {
 	header, err := jws.Header{
 		ALG: "ES256K",
 		KID: did.Document.VerificationMethod[0].ID,
-	}.Base64UrlEncode()
+	}.Encode()
 
 	assert.NoError(t, err)
 

--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -64,8 +64,8 @@ type Claims struct {
 }
 
 type DecodedJWT struct {
-	Header Header
-	Claims Claims
+	Header    Header
+	Claims    Claims
 	Signature string
 }
 

--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -12,9 +12,117 @@ import (
 	"github.com/tbd54566975/web5-go/jws"
 )
 
+// Decode decodes the 3-part base64url encoded jwt into it's relevant parts
+func Decode(jwt string) (Decoded, error) {
+	parts := strings.Split(jwt, ".")
+	if len(parts) != 3 {
+		return Decoded{}, fmt.Errorf("malformed JWT. Expected 3 parts, got %d", len(parts))
+	}
+
+	header, err := jws.DecodeHeader(parts[0])
+	if err != nil {
+		return Decoded{}, err
+	}
+
+	claimsBytes, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return Decoded{}, fmt.Errorf("malformed JWT. Failed to decode claims: %w", err)
+	}
+
+	claims := Claims{}
+	err = json.Unmarshal(claimsBytes, &claims)
+	if err != nil {
+		return Decoded{}, fmt.Errorf("malformed JWT. Failed to unmarshal claims: %w", err)
+	}
+
+	signature, err := jws.DecodeSignature(parts[2])
+	if err != nil {
+		return Decoded{}, fmt.Errorf("malformed JWT. Failed to decode signature: %w", err)
+	}
+
+	return Decoded{
+		Header:    header,
+		Claims:    claims,
+		Signature: signature,
+		Parts:     parts,
+	}, nil
+}
+
+// signOpts is a type that holds all the options that can be passed to Sign
+type signOpts struct{ selector didcore.VMSelector }
+
+// SignOpt is a type returned by all individual Sign Options.
+type SignOpt func(opts *signOpts)
+
+// Purpose is an option that can be provided to Sign to specify that a key from
+// a given DID Document Verification Relationship should be used (e.g. authentication)
+// Purpose is an option that can be passed to [github.com/tbd54566975/web5-go/jws.Sign].
+// It is used to select the appropriate key to sign with
+func Purpose(p string) SignOpt {
+	return func(opts *signOpts) {
+		opts.selector = didcore.Purpose(p)
+	}
+}
+
+// Sign signs the provided JWT Claims with the provided BearerDID.
+// The Purpose option can be provided to specify that a key from a given
+// DID Document Verification Relationship should be used (e.g. authentication).
+// defaults to using assertionMethod
+func Sign(claims Claims, did did.BearerDID, opts ...SignOpt) (string, error) {
+	o := signOpts{selector: nil}
+	for _, opt := range opts {
+		opt(&o)
+	}
+
+	return jws.Sign(claims, did, jws.VMSelector(o.selector))
+}
+
+// Verify verifies a JWT (JSON Web Token) as per the spec https://datatracker.ietf.org/doc/html/rfc7519
+// Successful verification means that the JWT has not expired and the signature's integrity is intact
+// Decoded JWT is returned if verification is successful
+func Verify(jwt string) (Decoded, error) {
+	decodedJWT, err := Decode(jwt)
+	if err != nil {
+		return Decoded{}, err
+	}
+
+	err = decodedJWT.Verify()
+
+	return decodedJWT, err
+}
+
 // Header are JWS Headers. type aliasing because this could cause confusion
 // for non-neckbeards
 type Header = jws.Header
+
+// Decoded represents a JWT Decoded into it's relevant parts
+type Decoded struct {
+	Header    Header
+	Claims    Claims
+	Signature []byte
+	Parts     []string
+}
+
+// Verify verifies a JWT (JSON Web Token)
+func (jwt Decoded) Verify() error {
+	if jwt.Claims.Expiration != 0 && time.Now().Unix() > int64(jwt.Claims.Expiration) {
+		return fmt.Errorf("JWT has expired")
+	}
+
+	decodedJWS := jws.Decoded{
+		Header:    jwt.Header,
+		Payload:   jwt.Claims,
+		Signature: jwt.Signature,
+		Parts:     jwt.Parts,
+	}
+
+	err := decodedJWS.Verify()
+	if err != nil {
+		return fmt.Errorf("JWT signature verification failed: %w", err)
+	}
+
+	return nil
+}
 
 // Claims represents JWT (JSON Web Token) Claims
 //
@@ -63,15 +171,6 @@ type Claims struct {
 	Misc map[string]interface{} `json:"-"`
 }
 
-type DecodedJWT struct {
-	Header    Header
-	Claims    Claims
-	Signature string
-}
-
-// cpy is a copy of Claims that is used to marshal/unmarshal the claims without infinitely looping
-type cpy Claims
-
 // MarshalJSON overrides default json.Marshal behavior to include misc claims as flattened
 // properties of the top-level object
 func (c Claims) MarshalJSON() ([]byte, error) {
@@ -110,10 +209,10 @@ func (c *Claims) UnmarshalJSON(b []byte) error {
 		"jti": true,
 	}
 
-	private := make(map[string]interface{})
+	misc := make(map[string]any)
 	for key, value := range m {
 		if _, ok := registeredClaims[key]; !ok {
-			private[key] = value
+			misc[key] = value
 		}
 	}
 
@@ -122,95 +221,11 @@ func (c *Claims) UnmarshalJSON(b []byte) error {
 		return err
 	}
 
-	claims.Misc = private
+	claims.Misc = misc
 	*c = Claims(claims)
 
 	return nil
 }
 
-type signOpts struct{ selector didcore.VMSelector }
-
-// SignOpt is a type returned by all individual Sign Options.
-type SignOpt func(opts *signOpts)
-
-// Purpose is an option that can be provided to Sign to specify that a key from
-// a given DID Document Verification Relationship should be used (e.g. authentication)
-// Purpose is an option that can be passed to [github.com/tbd54566975/web5-go/jws.Sign].
-// It is used to select the appropriate key to sign with
-func Purpose(p string) SignOpt {
-	return func(opts *signOpts) {
-		opts.selector = didcore.Purpose(p)
-	}
-}
-
-// Sign signs the provided JWT Claims with the provided BearerDID.
-// The Purpose option can be provided to specify that a key from a given
-// DID Document Verification Relationship should be used (e.g. authentication).
-// defaults to using assertionMethod
-func Sign(claims Claims, did did.BearerDID, opts ...SignOpt) (string, error) {
-	o := signOpts{selector: nil}
-	for _, opt := range opts {
-		opt(&o)
-	}
-
-	return jws.Sign(claims, did, jws.VMSelector(o.selector))
-}
-
-// Verify verifies a JWT (JSON Web Token)
-func Verify(jwt string) (bool, error) {
-	decodedJWT, err := Decode(jwt)
-	if err != nil {
-		return false, err
-	}
-
-	return decodedJWT.Verify()
-}
-
-// DecodeClaims decodes the base64url encoded JWT claims.
-func DecodeClaims(base64UrlEncodedClaims string) (Claims, error) {
-	bytes, err := base64.RawURLEncoding.DecodeString(base64UrlEncodedClaims)
-	if err != nil {
-		return Claims{}, err
-	}
-
-	var claims Claims
-	err = json.Unmarshal(bytes, &claims)
-	if err != nil {
-		return Claims{}, err
-	}
-
-	return claims, nil
-}
-
-// Decode decodes the 3-part base64url encoded jwt into it's relevant parts
-func Decode(jwt string) (DecodedJWT, error) {
-	parts := strings.Split(jwt, ".")
-	if len(parts) != 3 {
-		return DecodedJWT{}, fmt.Errorf("malformed JWT. Expected 3 parts, got %d", len(parts))
-	}
-
-	base64UrlEncodedHeader := parts[0]
-	base64UrlEncodedClaims := parts[1]
-	signature := parts[2]
-
-	header, err := jws.DecodeHeader(base64UrlEncodedHeader)
-	if err != nil {
-		return DecodedJWT{}, err
-	}
-
-	claims, err := DecodeClaims(base64UrlEncodedClaims)
-	if err != nil {
-		return DecodedJWT{}, err
-	}
-
-	return DecodedJWT{Header: header, Claims: claims, Signature: signature}, nil
-}
-
-// Verify verifies a JWT (JSON Web Token)
-func (jwt DecodedJWT) Verify() (bool, error) {
-	if jwt.Claims.Expiration != 0 && time.Now().Unix() > int64(jwt.Claims.Expiration) {
-		return false, fmt.Errorf("JWT has expired")
-	}
-
-	return jws.Verify(jwt) // todo
-}
+// cpy is a copy of Claims that is used to marshal/unmarshal the claims without infinitely looping
+type cpy Claims

--- a/jwt/jwt_test.go
+++ b/jwt/jwt_test.go
@@ -3,7 +3,6 @@ package jwt_test
 import (
 	"encoding/json"
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/alecthomas/assert/v2"
@@ -69,47 +68,23 @@ func TestVerify(t *testing.T) {
 		Misc:   map[string]interface{}{"c_nonce": "abcd123"},
 	}
 
-	signedJwt, err := jwt.Sign(claims, did)
+	signedJWT, err := jwt.Sign(claims, did)
 	assert.NoError(t, err)
 
-	assert.False(t, signedJwt == "", "expected jwt to not be empty")
+	assert.False(t, signedJWT == "", "expected jwt to not be empty")
 
-	verified, err := jwt.Verify(signedJwt)
+	decoded, err := jwt.Verify(signedJWT)
 	assert.NoError(t, err)
-
-	assert.True(t, verified, "expected verified")
+	assert.NotEqual(t, decoded, jwt.Decoded{}, "expected decoded to not be empty")
 }
 
 func TestVerify_BadClaims(t *testing.T) {
 	okHeader, err := jws.Header{ALG: "ES256K", KID: "did:web:abc#key-1"}.Base64UrlEncode()
 	assert.NoError(t, err)
-	
+
 	input := fmt.Sprintf("%s.%s.%s", okHeader, "hehe", "hehe")
 
-	verified, err := jwt.Verify(input)
+	decoded, err := jwt.Verify(input)
 	assert.Error(t, err)
-	assert.False(t, verified, "expected !verified")
-}
-
-func TestDecodeClaims(t *testing.T) {
-	did, err := didjwk.Create()
-	assert.NoError(t, err)
-
-	nonce := "abcd123"
-	claims := jwt.Claims{
-		Issuer: did.ID,
-		Misc:   map[string]interface{}{"c_nonce": nonce},
-	}
-
-	signedJwt, err := jwt.Sign(claims, did)
-	assert.NoError(t, err)
-
-	parts := strings.Split(signedJwt, ".")
-	assert.Equal(t, 3, len(parts), "expected 3 parts in JWT")
-	base64UrlEncodedClaims := parts[1]
-
-	decodedClaims, err := jwt.DecodeClaims(base64UrlEncodedClaims)
-	assert.NoError(t, err)
-	assert.Equal(t, claims.Issuer, decodedClaims.Issuer)
-	assert.Equal(t, claims.Misc["c_nonce"], decodedClaims.Misc["c_nonce"])
+	assert.Equal(t, jwt.Decoded{}, decoded)
 }

--- a/jwt/jwt_test.go
+++ b/jwt/jwt_test.go
@@ -79,7 +79,7 @@ func TestVerify(t *testing.T) {
 }
 
 func TestVerify_BadClaims(t *testing.T) {
-	okHeader, err := jws.Header{ALG: "ES256K", KID: "did:web:abc#key-1"}.Base64UrlEncode()
+	okHeader, err := jws.Header{ALG: "ES256K", KID: "did:web:abc#key-1"}.Encode()
 	assert.NoError(t, err)
 
 	input := fmt.Sprintf("%s.%s.%s", okHeader, "hehe", "hehe")


### PR DESCRIPTION
# Overview
Collaborative effort with @KendallWeihe to split `Verify` into two distinct functions `Decode` and `Verify`

> [!IMPORTANT]
> Most of the code changes in this PR are from moving things around. not much net new logic was added

# Rationale
we've run into multiple scenarios where we need to:
1. verify a JWT or JWS _and then_ use a number of fields from within the header or the payload/claims
2. _decode_ a JWT or JWS, check some stuff within the payload or headers, _and then_ verify

In order to access claims within a JWT the caller currently has to do this:
```go
package main

import (
    "encoding/json"
    "fmt"

    "github.com/tbd54566975/web5-go/jwt"
)

func main() {
        signedJwt := "eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDpqd2s6ZXlKcmRIa2lPaUpQUzFBaUxDSmpjbllpT2lKRlpESTFOVEU1SWl3aWVDSTZJbFpyU3pKclRscDVVREY0WVZwUFoyZHBjREY2VTJwc1JXTnNTakZSTVhSQmMxRkJhVU5YUW1GaVgyOGlmUSMwIn0." +
    "eyJjX25vbmNlIjoiYWJjZDEyMyIsImlzcyI6ImV5SnJkSGtpT2lKUFMxQWlMQ0pqY25ZaU9pSkZaREkxTlRFNUlpd2llQ0k2SWxaclN6SnJUbHA1VURGNFlWcFBaMmRwY0RGNlUycHNSV05zU2pGUk1YUkJjMUZCYVVOWFFtRmlYMjhpZlEifQ." +
    "O434_IlnJOYbcIsHkVcOyKLxVvcfHvcg6tZL_gIU2TAY6qFiaPZ_w6upSzIl-I8JXYBytzR_8BfCq4P3che1Bg"

    parts := strings.Split(signedJwt, ".")
    
    base64UrlEncodedClaims := parts[1]

    decodedClaims, err := jwt.DecodeJWTClaims(base64UrlEncodedClaims)

    if err != nil {
        panic(err)
    }
```

The above code ends up making it such that callers have to know more details than they have to about jwt details. further, if they've already verified the jwt, the claims are now being decoded twice. 

# Changes

In order to remedy the above, this PR splits decoding and verifying into two distinct steps while still providing a single function call if desired

## JWT

### Approach 1
```go
package main

import "github.com/tbd54566975/web5-go/jwt"

func main() {
    // Approach 1: decode then verify as two separate steps
    decoded, err := jwt.Decode("test")
    if err != nil {
        panic(err)
    }

   // application specific business logic

    err = decoded.Verify()
    if err != nil {
        panic(err)
    }
}
```

This approach requires the caller to first decode the JWT, perform whatever business logic is needed and then optionally call verify when desired

### Approach 2

```go
package main

import "github.com/tbd54566975/web5-go/jwt"

func main() {
    // Approach 2: decode & verify in 1 step and receive decoded jwt on successful verification
    decoded, err = jwt.Verify("test")
    if err != nil {
        panic(err)
    }
}
```

This allows to caller to call verify and then decide to perform additional logic using the claims within a JWT depending on the result of verification


## JWS
the `jws` API surface is identical to `jwt`

### Approach 1
```go
package main

import "github.com/tbd54566975/web5-go/jws"

func main() {
    // Approach 1: decode then verify as two separate steps
    decoded, err := jws.Decode("test")
    if err != nil {
        panic(err)
    }

    err = decoded.Verify()
    if err != nil {
        panic(err)
    }
}
```


### Approach 2
```go
package main

import "github.com/tbd54566975/web5-go/jws"

func main() {
    // Approach 2: decode & verify in 1 step and receive decoded jwt on successful verification
    decoded, err = jws.Verify("test")
    if err != nil {
        panic(err)
    }
}
```