### PR TITLE
Add generic for jws.Decoded type's Payload

### DIFF
--- a/jws/jws_test.go
+++ b/jws/jws_test.go
@@ -21,7 +21,7 @@ func TestDecode(t *testing.T) {
 	compactJWS, err := jws.Sign(payloadJSON, did)
 	assert.NoError(t, err)
 
-	decoded, err := jws.Decode(compactJWS)
+	decoded, err := jws.Decode[any](compactJWS)
 	assert.NoError(t, err)
 
 	payload, ok := decoded.Payload.(map[string]any)
@@ -39,10 +39,10 @@ func TestDecode_Bad(t *testing.T) {
 	}
 
 	for _, vector := range vectors {
-		decoded, err := jws.Decode(vector)
+		decoded, err := jws.Decode[any](vector)
 
 		assert.Error(t, err, "expected verification error. vector: %s", vector)
-		assert.Equal(t, jws.Decoded{}, decoded, "expected empty DecodedJWS")
+		assert.Equal(t, jws.Decoded[any]{}, decoded, "expected empty DecodedJWS")
 	}
 }
 
@@ -109,9 +109,9 @@ func TestDecoded_Verify(t *testing.T) {
 	compactJWS, err := jws.Sign(payloadJSON, did)
 	assert.NoError(t, err)
 
-	decoded, err := jws.Decode(compactJWS)
+	decoded, err := jws.Decode[any](compactJWS)
 	assert.NoError(t, err)
-	assert.NotEqual(t, jws.Decoded{}, decoded, "expected decoded to not be empty")
+	assert.NotEqual(t, jws.Decoded[any]{}, decoded, "expected decoded to not be empty")
 }
 
 func TestDecoded_Verify_Bad(t *testing.T) {
@@ -130,7 +130,7 @@ func TestDecoded_Verify_Bad(t *testing.T) {
 
 	compactJWS := fmt.Sprintf("%s.%s.%s", header, payload, payload)
 
-	_, err = jws.Verify(compactJWS)
+	_, err = jws.Verify[any](compactJWS)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "signature")
 }
@@ -143,6 +143,6 @@ func TestVerify(t *testing.T) {
 	compactJWS, err := jws.Sign(payloadJSON, did)
 	assert.NoError(t, err)
 
-	_, err = jws.Verify(compactJWS)
+	_, err = jws.Verify[any](compactJWS)
 	assert.NoError(t, err)
 }

--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -42,7 +42,7 @@ func Decode(jwt string) (Decoded, error) {
 
 	return Decoded{
 		Header:    header,
-		Claims:    claims,
+		Payload:    claims,
 		Signature: signature,
 		Parts:     parts,
 	}, nil
@@ -96,22 +96,17 @@ func Verify(jwt string) (Decoded, error) {
 type Header = jws.Header
 
 // Decoded represents a JWT Decoded into it's relevant parts
-type Decoded struct {
-	Header    Header
-	Claims    Claims
-	Signature []byte
-	Parts     []string
-}
+type Decoded jws.Decoded[Claims]
 
 // Verify verifies a JWT (JSON Web Token)
 func (jwt Decoded) Verify() error {
-	if jwt.Claims.Expiration != 0 && time.Now().Unix() > int64(jwt.Claims.Expiration) {
+	if jwt.Payload.Expiration != 0 && time.Now().Unix() > int64(jwt.Payload.Expiration) {
 		return fmt.Errorf("JWT has expired")
 	}
 
-	decodedJWS := jws.Decoded{
+	decodedJWS := jws.Decoded[Claims]{
 		Header:    jwt.Header,
-		Payload:   jwt.Claims,
+		Payload:   jwt.Payload,
 		Signature: jwt.Signature,
 		Parts:     jwt.Parts,
 	}

--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -42,7 +42,7 @@ func Decode(jwt string) (Decoded, error) {
 
 	return Decoded{
 		Header:    header,
-		Payload:    claims,
+		Payload:   claims,
 		Signature: signature,
 		Parts:     parts,
 	}, nil


### PR DESCRIPTION
@mistermoe I thought of this when I was reviewing [this PR](https://github.com/TBD54566975/web5-go/pull/43) earlier

Idk I'm a little conflicted, sometimes I think generics are not a great DX, other times I do. So just throwing it out there for the sake of discussion. LMK!