### PR TITLE
Configure vscode to run linter on the whole package when a file is saved

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,4 +3,5 @@
   "go.lintFlags": [
     "--fast"
   ],
+  "go.lintOnSave": "package"
 }


### PR DESCRIPTION
To avoid lint issues getting to PRs and `main` branch, this will highlight lint issues directly in VS Code