### PR TITLE
Add DID resolve to web5 cmd

### DIFF
--- a/cmd/web5/README.md
+++ b/cmd/web5/README.md
@@ -6,13 +6,16 @@
 ➜ web5 -h
 Usage: web5 <command>
 
-Web5 - A decentralized web platform that puts you in
-control of your data and identity.
+Web5 - A decentralized web platform that puts you in control of your
+data and identity.
 
 Flags:
   -h, --help    Show context-sensitive help.
 
 Commands:
+  did resolve <uri>
+    Resolve a DID.
+
   did:jwk create
     Create a did:jwk.
 

--- a/cmd/web5/cmd_did.go
+++ b/cmd/web5/cmd_did.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/tbd54566975/web5-go/dids"
+)
+
+type didResolve struct {
+	URI string `arg:"" name:"uri" help:"The URI to resolve."`
+}
+
+func (c *didResolve) Run(_ context.Context) error {
+	fmt.Println(c.URI)
+
+	result, err := dids.Resolve(c.URI)
+	if err != nil {
+		return err
+	}
+
+	jsonDID, err := json.MarshalIndent(result.Document, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(string(jsonDID))
+
+	return nil
+}
+
+type didCmd struct {
+	Resolve didResolve `cmd:"" help:"Resolve a DID."`
+}

--- a/cmd/web5/cmd_did.go
+++ b/cmd/web5/cmd_did.go
@@ -8,13 +8,11 @@ import (
 	"github.com/tbd54566975/web5-go/dids"
 )
 
-type didResolve struct {
+type didResolveCmd struct {
 	URI string `arg:"" name:"uri" help:"The URI to resolve."`
 }
 
-func (c *didResolve) Run(_ context.Context) error {
-	fmt.Println(c.URI)
-
+func (c *didResolveCmd) Run(_ context.Context) error {
 	result, err := dids.Resolve(c.URI)
 	if err != nil {
 		return err
@@ -31,5 +29,5 @@ func (c *didResolve) Run(_ context.Context) error {
 }
 
 type didCmd struct {
-	Resolve didResolve `cmd:"" help:"Resolve a DID."`
+	Resolve didResolveCmd `cmd:"" help:"Resolve a DID."`
 }

--- a/cmd/web5/cmd_did.go
+++ b/cmd/web5/cmd_did.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 
@@ -12,7 +11,7 @@ type didResolveCmd struct {
 	URI string `arg:"" name:"uri" help:"The URI to resolve."`
 }
 
-func (c *didResolveCmd) Run(_ context.Context) error {
+func (c *didResolveCmd) Run() error {
 	result, err := dids.Resolve(c.URI)
 	if err != nil {
 		return err

--- a/cmd/web5/cmd_didjwk.go
+++ b/cmd/web5/cmd_didjwk.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 
@@ -10,7 +9,7 @@ import (
 
 type didJWKCreate struct{}
 
-func (c *didJWKCreate) Run(_ context.Context) error {
+func (c *didJWKCreate) Run() error {
 	did, err := didjwk.Create()
 	if err != nil {
 		return err

--- a/cmd/web5/cmd_didweb.go
+++ b/cmd/web5/cmd_didweb.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 
@@ -12,7 +11,7 @@ type didWebCreate struct {
 	Domain string `arg:"" help:"The domain name for the DID." required:""`
 }
 
-func (c *didWebCreate) Run(_ context.Context) error {
+func (c *didWebCreate) Run() error {
 	did, err := didweb.Create(c.Domain)
 	if err != nil {
 		return err

--- a/cmd/web5/main.go
+++ b/cmd/web5/main.go
@@ -7,6 +7,7 @@ import (
 )
 
 type CLI struct {
+	DID didCmd `cmd:"" help:"Interface with DID's."`
 	DIDJWK didJWKCmd `cmd:"" name:"did:jwk" help:"Manage did:jwk's."`
 	DIDWeb didWebCmd `cmd:"" name:"did:web" help:"Manage did:web's."`
 }


### PR DESCRIPTION
Closes https://github.com/TBD54566975/web5-go/issues/70

---

## Usage

```shell
web5 did resolve <uri>
```

For example, run `web5 did:jwk create`, and use the `uri` from the output as the input to the resolve command

## Commentary

I think I may redo the DX for the `did:jwk` and `did:web` to be `web5 did create <method> <additional args>` ... @mistermoe thoughts? My driving reason is to try and match the namespacing in our various web SDKs (specifically looking at web5-js as the most mature among them)

I want to be able to resolve a DID with just the URI, so I would want the create commands to be consistent with this DX as well