### PR TITLE
Fix linting issues caused by lack of godoc comments

### DIFF
--- a/cmd/web5/main.go
+++ b/cmd/web5/main.go
@@ -6,13 +6,11 @@ import (
 	"github.com/alecthomas/kong"
 )
 
-type CLI struct {
-	DID didCmd `cmd:"" help:"Interface with DID's."`
+var cli struct {
+	DID    didCmd    `cmd:"" help:"Interface with DID's."`
 	DIDJWK didJWKCmd `cmd:"" name:"did:jwk" help:"Manage did:jwk's."`
 	DIDWeb didWebCmd `cmd:"" name:"did:web" help:"Manage did:web's."`
 }
-
-var cli CLI
 
 func main() {
 	kctx := kong.Parse(&cli,

--- a/crypto/dsa/dsa.go
+++ b/crypto/dsa/dsa.go
@@ -95,6 +95,7 @@ func PublicKeyToBytes(publicKey jwk.JWK) ([]byte, error) {
 	}
 }
 
+// AlgorithmID returns the algorithm ID for the given jwk.JWK
 func AlgorithmID(jwk *jwk.JWK) (string, error) {
 	switch jwk.KTY {
 	case ecdsa.KeyType:

--- a/crypto/dsa/ecdsa/ecdsa.go
+++ b/crypto/dsa/ecdsa/ecdsa.go
@@ -15,6 +15,7 @@ var algorithmIDs = map[string]bool{
 	SECP256K1AlgorithmID: true,
 }
 
+// GeneratePrivateKey generates a private key for the given algorithm
 func GeneratePrivateKey(algorithmID string) (jwk.JWK, error) {
 	switch algorithmID {
 	case SECP256K1AlgorithmID:
@@ -24,6 +25,7 @@ func GeneratePrivateKey(algorithmID string) (jwk.JWK, error) {
 	}
 }
 
+// GetPublicKey builds an ECDSA public key from the given ECDSA private key
 func GetPublicKey(privateKey jwk.JWK) jwk.JWK {
 	return jwk.JWK{
 		KTY: privateKey.KTY,
@@ -33,6 +35,11 @@ func GetPublicKey(privateKey jwk.JWK) jwk.JWK {
 	}
 }
 
+// Sign generates a cryptographic signature for the given payload with the given private key
+//
+// # Note
+//
+// The function will automatically detect the given ECDSA cryptographic curve from the given private key
 func Sign(payload []byte, privateKey jwk.JWK) ([]byte, error) {
 	if privateKey.D == "" {
 		return nil, errors.New("d must be set")
@@ -46,6 +53,11 @@ func Sign(payload []byte, privateKey jwk.JWK) ([]byte, error) {
 	}
 }
 
+// Verify verified the given signature over a given payload by the given public key
+//
+// # Note
+//
+// The function will automatically detect the given ECDSA cryptographic curve from the given public key
 func Verify(payload []byte, signature []byte, publicKey jwk.JWK) (bool, error) {
 	switch publicKey.CRV {
 	case SECP256K1JWACurve:
@@ -55,6 +67,9 @@ func Verify(payload []byte, signature []byte, publicKey jwk.JWK) (bool, error) {
 	}
 }
 
+// GetJWA returns the [JWA] for the given ECDSA key
+//
+// [JWA]: https://datatracker.ietf.org/doc/html/rfc7518
 func GetJWA(jwk jwk.JWK) (string, error) {
 	switch jwk.CRV {
 	case SECP256K1JWACurve:
@@ -64,6 +79,7 @@ func GetJWA(jwk jwk.JWK) (string, error) {
 	}
 }
 
+// BytesToPublicKey deserializes the given byte array into a jwk.JWK for the given cryptographic algorithm
 func BytesToPublicKey(algorithmID string, input []byte) (jwk.JWK, error) {
 	switch algorithmID {
 	case SECP256K1AlgorithmID:
@@ -73,6 +89,7 @@ func BytesToPublicKey(algorithmID string, input []byte) (jwk.JWK, error) {
 	}
 }
 
+// PublicKeyToBytes serializes the given public key into a byte array
 func PublicKeyToBytes(publicKey jwk.JWK) ([]byte, error) {
 	switch publicKey.CRV {
 	case SECP256K1JWACurve:
@@ -82,10 +99,12 @@ func PublicKeyToBytes(publicKey jwk.JWK) ([]byte, error) {
 	}
 }
 
+// SupportsAlgorithmID informs as to whether or not the given algorithm ID is supported by this package
 func SupportsAlgorithmID(id string) bool {
 	return algorithmIDs[id]
 }
 
+// AlgorithmID returns the algorithm ID for the given jwk.JWK
 func AlgorithmID(jwk *jwk.JWK) (string, error) {
 	switch jwk.CRV {
 	case SECP256K1JWACurve:

--- a/crypto/dsa/ecdsa/ecdsa.go
+++ b/crypto/dsa/ecdsa/ecdsa.go
@@ -15,7 +15,7 @@ var algorithmIDs = map[string]bool{
 	SECP256K1AlgorithmID: true,
 }
 
-// GeneratePrivateKey generates a private key for the given algorithm
+// GeneratePrivateKey generates an ECDSA private key for the given algorithm
 func GeneratePrivateKey(algorithmID string) (jwk.JWK, error) {
 	switch algorithmID {
 	case SECP256K1AlgorithmID:
@@ -53,7 +53,7 @@ func Sign(payload []byte, privateKey jwk.JWK) ([]byte, error) {
 	}
 }
 
-// Verify verified the given signature over a given payload by the given public key
+// Verify verifies the given signature over a given payload by the given public key
 //
 // # Note
 //

--- a/crypto/dsa/ecdsa/secp256k1.go
+++ b/crypto/dsa/ecdsa/secp256k1.go
@@ -17,6 +17,7 @@ const (
 	SECP256K1AlgorithmID string = SECP256K1JWACurve
 )
 
+// SECP256K1GeneratePrivateKey generates a new private key
 func SECP256K1GeneratePrivateKey() (jwk.JWK, error) {
 	keyPair, err := _secp256k1.GeneratePrivateKey()
 	if err != nil {
@@ -39,6 +40,7 @@ func SECP256K1GeneratePrivateKey() (jwk.JWK, error) {
 	return privateKey, nil
 }
 
+// SECP256K1Sign signs the given payload with the given private key
 func SECP256K1Sign(payload []byte, privateKey jwk.JWK) ([]byte, error) {
 	privateKeyBytes, err := base64.RawURLEncoding.DecodeString(privateKey.D)
 	if err != nil {
@@ -53,6 +55,7 @@ func SECP256K1Sign(payload []byte, privateKey jwk.JWK) ([]byte, error) {
 	return signature, nil
 }
 
+// SECP256K1Verify verifies the given signature over the given payload with the given public key
 func SECP256K1Verify(payload []byte, signature []byte, publicKey jwk.JWK) (bool, error) {
 	if publicKey.X == "" || publicKey.Y == "" {
 		return false, errors.New("x and y must be set")

--- a/crypto/dsa/eddsa/ed25519.go
+++ b/crypto/dsa/eddsa/ed25519.go
@@ -15,6 +15,7 @@ const (
 	ED25519AlgorithmID string = ED25519JWACurve
 )
 
+// ED25519GeneratePrivateKey generates a new ED25519 private key
 func ED25519GeneratePrivateKey() (jwk.JWK, error) {
 	publicKey, privateKey, err := _ed25519.GenerateKey(rand.Reader)
 	if err != nil {
@@ -31,6 +32,7 @@ func ED25519GeneratePrivateKey() (jwk.JWK, error) {
 	return privKeyJwk, nil
 }
 
+// ED25519Sign signs the given payload with the given private key
 func ED25519Sign(payload []byte, privateKey jwk.JWK) ([]byte, error) {
 	privateKeyBytes, err := base64.RawURLEncoding.DecodeString(privateKey.D)
 	if err != nil {
@@ -41,6 +43,7 @@ func ED25519Sign(payload []byte, privateKey jwk.JWK) ([]byte, error) {
 	return signature, nil
 }
 
+// ED25519Verify verifies the given signature against the given payload using the given public key
 func ED25519Verify(payload []byte, signature []byte, publicKey jwk.JWK) (bool, error) {
 	publicKeyBytes, err := base64.RawURLEncoding.DecodeString(publicKey.X)
 	if err != nil {
@@ -51,6 +54,7 @@ func ED25519Verify(payload []byte, signature []byte, publicKey jwk.JWK) (bool, e
 	return legit, nil
 }
 
+// ED25519BytesToPublicKey deserializes the byte array into a jwk.JWK public key
 func ED25519BytesToPublicKey(input []byte) (jwk.JWK, error) {
 	if len(input) != _ed25519.PublicKeySize {
 		return jwk.JWK{}, errors.New("invalid public key")
@@ -63,7 +67,7 @@ func ED25519BytesToPublicKey(input []byte) (jwk.JWK, error) {
 	}, nil
 }
 
-// ED25519PublicKeyToBytes converts the provided public key to bytes
+// ED25519PublicKeyToBytes serializes the given public key int a byte array
 func ED25519PublicKeyToBytes(publicKey jwk.JWK) ([]byte, error) {
 	if publicKey.X == "" {
 		return nil, errors.New("x must be set")

--- a/crypto/dsa/eddsa/eddsa.go
+++ b/crypto/dsa/eddsa/eddsa.go
@@ -18,6 +18,7 @@ var algorithmIDs = map[string]bool{
 	ED25519AlgorithmID: true,
 }
 
+// GeneratePrivateKey generates an EdDSA private key for the given algorithm
 func GeneratePrivateKey(algorithmID string) (jwk.JWK, error) {
 	switch algorithmID {
 	case ED25519AlgorithmID:
@@ -27,6 +28,7 @@ func GeneratePrivateKey(algorithmID string) (jwk.JWK, error) {
 	}
 }
 
+// GetPublicKey builds an EdDSA public key from the given EdDSA private key
 func GetPublicKey(privateKey jwk.JWK) jwk.JWK {
 	return jwk.JWK{
 		KTY: privateKey.KTY,
@@ -35,6 +37,11 @@ func GetPublicKey(privateKey jwk.JWK) jwk.JWK {
 	}
 }
 
+// Sign generates a cryptographic signature for the given payload with the given private key
+//
+// # Note
+//
+// The function will automatically detect the given EdDSA cryptographic curve from the given private key
 func Sign(payload []byte, privateKey jwk.JWK) ([]byte, error) {
 	if privateKey.D == "" {
 		return nil, errors.New("d must be set")
@@ -48,6 +55,11 @@ func Sign(payload []byte, privateKey jwk.JWK) ([]byte, error) {
 	}
 }
 
+// Verify verifies the given signature over a given payload by the given public key
+//
+// # Note
+//
+// The function will automatically detect the given EdDSA cryptographic curve from the given public key
 func Verify(payload []byte, signature []byte, publicKey jwk.JWK) (bool, error) {
 	switch publicKey.CRV {
 	case ED25519JWACurve:
@@ -57,10 +69,18 @@ func Verify(payload []byte, signature []byte, publicKey jwk.JWK) (bool, error) {
 	}
 }
 
+// GetJWA returns the [JWA] for the given EdDSA key
+//
+// # Note
+//
+// The only supported [JWA] is "EdDSA"
+//
+// [JWA]: https://datatracker.ietf.org/doc/html/rfc7518
 func GetJWA(jwk jwk.JWK) (string, error) {
 	return JWA, nil
 }
 
+// BytesToPublicKey deserializes the given byte array into a jwk.JWK for the given cryptographic algorithm
 func BytesToPublicKey(algorithmID string, input []byte) (jwk.JWK, error) {
 	switch algorithmID {
 	case ED25519AlgorithmID:
@@ -70,6 +90,7 @@ func BytesToPublicKey(algorithmID string, input []byte) (jwk.JWK, error) {
 	}
 }
 
+// PublicKeyToBytes serializes the given public key into a byte array
 func PublicKeyToBytes(publicKey jwk.JWK) ([]byte, error) {
 	switch publicKey.CRV {
 	case ED25519JWACurve:
@@ -79,10 +100,12 @@ func PublicKeyToBytes(publicKey jwk.JWK) ([]byte, error) {
 	}
 }
 
+// SupportsAlgorithmID informs as to whether or not the given algorithm ID is supported by this package
 func SupportsAlgorithmID(id string) bool {
 	return algorithmIDs[id]
 }
 
+// AlgorithmID returns the algorithm ID for the given jwk.JWK
 func AlgorithmID(jwk *jwk.JWK) (string, error) {
 	switch jwk.CRV {
 	case ED25519JWACurve:

--- a/crypto/entropy.go
+++ b/crypto/entropy.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 )
 
+// EntropySize represents the size of the entropy in bits, i.e. Entropy128 is equal to 128 bits (or 16 bytes) of entrop
 type EntropySize int
 
 // Directly set the sizes according to NIST recommendations for entropy

--- a/crypto/keymanager.go
+++ b/crypto/keymanager.go
@@ -20,10 +20,12 @@ type KeyManager interface {
 	Sign(keyID string, payload []byte) ([]byte, error)
 }
 
+// KeyExporter is an abstraction that can be leveraged to implement types which intend to export keys
 type KeyExporter interface {
 	ExportKey(keyID string) (jwk.JWK, error)
 }
 
+// KeyImporter is an abstraction that can be leveraged to implement types which intend to import keys
 type KeyImporter interface {
 	ImportKey(key jwk.JWK) (string, error)
 }
@@ -92,6 +94,7 @@ func (k *LocalKeyManager) getPrivateJWK(keyID string) (jwk.JWK, error) {
 	return key, nil
 }
 
+// ExportKey exports the key specific by the key ID from the [LocalKeyManager]
 func (k *LocalKeyManager) ExportKey(keyID string) (jwk.JWK, error) {
 	key, err := k.getPrivateJWK(keyID)
 	if err != nil {
@@ -101,6 +104,7 @@ func (k *LocalKeyManager) ExportKey(keyID string) (jwk.JWK, error) {
 	return key, nil
 }
 
+// ImportKey imports the key into the [LocalKeyManager] and returns the key alias
 func (k *LocalKeyManager) ImportKey(key jwk.JWK) (string, error) {
 	keyAlias, err := key.ComputeThumbprint()
 	if err != nil {

--- a/dids/did/did.go
+++ b/dids/did/did.go
@@ -50,10 +50,12 @@ func (d DID) String() string {
 	return d.URL
 }
 
+// MarshalText will convert the given DID's URL into a byte array
 func (d DID) MarshalText() (text []byte, err error) {
 	return []byte(d.String()), nil
 }
 
+// UnmarshalText will deserialize the given byte array into an instance of [DID]
 func (d *DID) UnmarshalText(text []byte) error {
 	did, err := Parse(string(text))
 	if err != nil {

--- a/dids/didcore/document.go
+++ b/dids/didcore/document.go
@@ -76,8 +76,10 @@ type addVMOptions struct {
 	purposes []Purpose
 }
 
+// AddVMOption is a type returned by all AddVerificationMethod options for variadic parameter support
 type AddVMOption func(o *addVMOptions)
 
+// Purposes can be used to select a verification method with a specific purpose.
 func Purposes(p ...Purpose) AddVMOption {
 	return func(o *addVMOptions) {
 		o.purposes = p
@@ -191,6 +193,7 @@ func (d *Document) SelectVerificationMethod(selector VMSelector) (VerificationMe
 	return VerificationMethod{}, fmt.Errorf("no verification method found for id: %s", vmID)
 }
 
+// AddService will append the given Service to the Document.Services array
 func (d *Document) AddService(service *Service) {
 	d.Service = append(d.Service, service)
 }

--- a/dids/didjwk/didjwk.go
+++ b/dids/didjwk/didjwk.go
@@ -19,6 +19,7 @@ type createOptions struct {
 	algorithmID string
 }
 
+// CreateOption is a type returned by all [Create] options for variadic parameter support
 type CreateOption func(o *createOptions)
 
 // KeyManager is an option that can be passed to Create to provide a KeyManager
@@ -82,8 +83,11 @@ func Create(opts ...CreateOption) (did.BearerDID, error) {
 	return bearerDID, nil
 }
 
+// Resolver is a type to implement resolution
 type Resolver struct{}
 
+// ResolveWithContext the provided DID URI (must be a did:jwk) as per the wee bit of detail provided in the
+// spec: https://github.com/quartzjer/did-jwk/blob/main/spec.md
 func (r Resolver) ResolveWithContext(ctx context.Context, uri string) (didcore.ResolutionResult, error) {
 	return r.Resolve(uri)
 }

--- a/dids/resolver.go
+++ b/dids/resolver.go
@@ -17,6 +17,8 @@ func Resolve(uri string) (didcore.ResolutionResult, error) {
 	return getDefaultResolver().Resolve(uri)
 }
 
+// ResolveWithContext resolves the provided DID URI. This function is capable of resolving
+// the DID methods implemented in web5-go
 func ResolveWithContext(ctx context.Context, uri string) (didcore.ResolutionResult, error) {
 	return getDefaultResolver().ResolveWithContext(ctx, uri)
 }

--- a/jws/jws.go
+++ b/jws/jws.go
@@ -99,12 +99,16 @@ func Purpose(p string) SignOpt {
 	}
 }
 
+// VerificationMethod is an option that can be passed to [github.com/tbd54566975/web5-go/jws.Sign].
+// It is used to select the appropriate key to sign with
 func VerificationMethod(id string) SignOpt {
 	return func(opts *signOpts) {
 		opts.selector = didcore.ID(id)
 	}
 }
 
+// VMSelector is an option that can be passed to [github.com/tbd54566975/web5-go/jws.Sign].
+// It is used to select the appropriate key to sign with
 func VMSelector(selector didcore.VMSelector) SignOpt {
 	return func(opts *signOpts) {
 		opts.selector = selector
@@ -182,6 +186,8 @@ func Sign(payload Payload, did _did.BearerDID, opts ...SignOpt) (string, error) 
 	return compactJWS, nil
 }
 
+// Verify verifies the given compactJWS by resolving the DID Document from the kid header value
+// and using the associated public key found by resolving the DID Document
 func Verify(compactJWS string) (Decoded, error) {
 	decodedJWS, err := Decode(compactJWS)
 	if err != nil {
@@ -193,6 +199,7 @@ func Verify(compactJWS string) (Decoded, error) {
 	return decodedJWS, err
 }
 
+// Decoded is a compact JWS decoded into it's parts
 type Decoded struct {
 	Header    Header
 	Payload   Payload
@@ -200,6 +207,8 @@ type Decoded struct {
 	Parts     []string
 }
 
+// Verify verifies the given compactJWS by resolving the DID Document from the kid header value
+// and using the associated public key found by resolving the DID Document
 func (jws Decoded) Verify() error {
 	if jws.Header.ALG == "" || jws.Header.KID == "" {
 		return errors.New("malformed JWS header. alg and kid are required")
@@ -264,4 +273,7 @@ func (j Header) Encode() (string, error) {
 	return base64.RawURLEncoding.EncodeToString(bytes), nil
 }
 
+// Payload is a type to represent the [JWS Payload]
+//
+// [JWS Payload]: https://datatracker.ietf.org/doc/html/rfc7515#section-2
 type Payload any

--- a/jws/jws.go
+++ b/jws/jws.go
@@ -13,6 +13,13 @@ import (
 	"github.com/tbd54566975/web5-go/dids/didcore"
 )
 
+// Decode decodes the given JWS string into a [Decoded] type
+//
+// # Note
+//
+// The given JWS input is assumed to be a [compact JWS]
+//
+// [compact JWS]: https://datatracker.ietf.org/doc/html/rfc7515#section-7.1
 func Decode(jws string) (Decoded, error) {
 	parts := strings.Split(jws, ".")
 	if len(parts) != 3 {
@@ -48,7 +55,7 @@ func Decode(jws string) (Decoded, error) {
 	}, nil
 }
 
-// DecodeHeader decodes the base64url encoded JWS header.
+// DecodeHeader decodes the base64url encoded JWS header into a [Header]
 func DecodeHeader(base64UrlEncodedHeader string) (Header, error) {
 	bytes, err := base64.RawURLEncoding.DecodeString(base64UrlEncodedHeader)
 	if err != nil {
@@ -64,6 +71,7 @@ func DecodeHeader(base64UrlEncodedHeader string) (Header, error) {
 	return header, nil
 }
 
+// DecodeSignature decodes the base64url encoded JWS signature into a byte array
 func DecodeSignature(base64UrlEncodedSignature string) ([]byte, error) {
 	signature, err := base64.RawURLEncoding.DecodeString(base64UrlEncodedSignature)
 	if err != nil {


### PR DESCRIPTION
Linting on main is currently failing because of a lot of lacking godoc comments for exported members. This PR adds the comments. In full transparency, I think the doc comments here are insufficient, in that a lot of comments need additional language added. I was hoping we could get the pipeline back to functional, so that linting is actually useful for current code changes, and then follow-up with [this ticket](https://github.com/TBD54566975/web5-go/issues/99) to add additional context and whatnot.  

---

This work spurred the creation of this ticket https://github.com/TBD54566975/web5-go/issues/98