### PR TITLE
Document.Context mixed types

### DIFF
--- a/dids/didcore/document.go
+++ b/dids/didcore/document.go
@@ -16,6 +16,9 @@ const (
 	PurposeKeyAgreement         Purpose = "keyAgreement"
 )
 
+// Context is a representation of the JSON-LD @context type from [the spec]
+//
+// [the spec]: https://www.w3.org/TR/did-core/#dfn-context
 type Context interface{}
 
 // Document represents a set of data describing the DID subject including mechanisms such as:

--- a/dids/didcore/document_test.go
+++ b/dids/didcore/document_test.go
@@ -1,6 +1,7 @@
 package didcore_test
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/alecthomas/assert/v2"
@@ -40,4 +41,44 @@ func TestWoo(t *testing.T) {
 	vm, err := doc.SelectVerificationMethod(didcore.Purpose("authentication"))
 	assert.NoError(t, err)
 	assert.Equal(t, "did:example:123456789abcdefghi#keys-1", vm.ID)
+}
+
+func TestUnmarshal_ContextString(t *testing.T) {
+	var doc didcore.Document
+	err := json.Unmarshal([]byte(`{
+        "@context": "https://www.w3.org/ns/did/v1"
+    }`), &doc)
+	assert.NoError(t, err)
+	assert.Equal(t, "https://www.w3.org/ns/did/v1", doc.Context)
+}
+
+func TestUnmarshal_ContextStringArray(t *testing.T) {
+	var doc didcore.Document
+	err := json.Unmarshal([]byte(`{
+        "@context": [
+            "https://www.w3.org/ns/did/v1",
+            "https://www.w3.org/ns/did/v1"
+        ]
+    }`), &doc)
+	assert.NoError(t, err)
+	context, ok := doc.Context.([]didcore.Context)
+	assert.True(t, ok)
+	assert.Equal(t, []didcore.Context{"https://www.w3.org/ns/did/v1", "https://www.w3.org/ns/did/v1"}, context)
+}
+
+func TestUnmarshal_ContextMixedTypes(t *testing.T) {
+	var doc didcore.Document
+	err := json.Unmarshal([]byte(`{
+        "@context": [
+            "https://www.w3.org/ns/did/v1",
+            { "@base": "did:web:www.linkedin.com" }
+        ]
+    }`), &doc)
+	assert.NoError(t, err)
+	context, ok := doc.Context.([]didcore.Context)
+	assert.True(t, ok)
+	assert.Equal(t, []didcore.Context{
+		"https://www.w3.org/ns/did/v1",
+		map[string]interface{}{"@base": "did:web:www.linkedin.com"},
+	}, context)
 }

--- a/dids/didcore/document_test.go
+++ b/dids/didcore/document_test.go
@@ -82,3 +82,19 @@ func TestUnmarshal_ContextMixedTypes(t *testing.T) {
 		map[string]interface{}{"@base": "did:web:www.linkedin.com"},
 	}, context)
 }
+
+func TestMarshal_ContextMixedType(t *testing.T) {
+	doc := didcore.Document{
+		ID: "whatev",
+		Context: []interface{}{
+			"https://www.w3.org/ns/did/v1",
+			map[string]interface{}{"@base": "did:web:www.linkedin.com"},
+		},
+	}
+
+	bytes, err := json.Marshal(&doc)
+	assert.NoError(t, err)
+	assert.Equal(t,
+		"{\"@context\":[\"https://www.w3.org/ns/did/v1\",{\"@base\":\"did:web:www.linkedin.com\"}],\"id\":\"whatev\"}",
+		string(bytes))
+}

--- a/dids/didcore/examples_test.go
+++ b/dids/didcore/examples_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Demonstrates how to unmarshal [Document]'s with mixed types, such as an array of both strings and ordered maps
-func ExampleDocument_UnmarshalJSON_contextWithMixedTypes() {
+func ExampleDocument_contextWithMixedTypes() {
 	var doc didcore.Document
 	err := json.Unmarshal([]byte(`{
 		"@context": [
@@ -25,14 +25,12 @@ func ExampleDocument_UnmarshalJSON_contextWithMixedTypes() {
 	if !ok {
 		panic(errors.New("error unmarshalling Document"))
 	}
-
 	fmt.Printf("Document @context array string item: %s\n", context[0])
 
 	orderedMap, ok := context[1].(map[string]interface{})
 	if !ok {
 		panic(errors.New("error unmarshalling Document"))
 	}
-
 	fmt.Printf("Document @context array ordered map item: %s", orderedMap)
 
 	// Output:

--- a/dids/didcore/examples_test.go
+++ b/dids/didcore/examples_test.go
@@ -1,0 +1,41 @@
+package didcore_test
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/tbd54566975/web5-go/dids/didcore"
+)
+
+// Demonstrates how to unmarshal [Document]'s with mixed types, such as an array of both strings and ordered maps
+func ExampleDocument_UnmarshalJSON_contextWithMixedTypes() {
+	var doc didcore.Document
+	err := json.Unmarshal([]byte(`{
+		"@context": [
+			"https://www.w3.org/ns/did/v1",
+			{ "@base": "did:web:www.linkedin.com" }
+		]
+	}`), &doc)
+	if err != nil {
+		panic(err)
+	}
+
+	context, ok := doc.Context.([]didcore.Context)
+	if !ok {
+		panic(errors.New("error unmarshalling Document"))
+	}
+
+	fmt.Printf("Document @context array string item: %s\n", context[0])
+
+	orderedMap, ok := context[1].(map[string]interface{})
+	if !ok {
+		panic(errors.New("error unmarshalling Document"))
+	}
+
+	fmt.Printf("Document @context array ordered map item: %s", orderedMap)
+
+	// Output:
+	// Document @context array string item: https://www.w3.org/ns/did/v1
+	// Document @context array ordered map item: map[@base:did:web:www.linkedin.com]
+}


### PR DESCRIPTION
Closes https://github.com/TBD54566975/web5-go/issues/92

When I implemented the `did:web` resolution work, I realized the `@context` property could be a string, an array of strings, or an array of strings and objects (and specifically, [LinkedIn's DID Doc](https://www.linkedin.com/.well-known/did.json) had the mixed types).

I implemented the work to support mixed types specifically for the `@context` property, but I also reviewed the spec and found other properties which are mixed type and need to be implemented (list below).

The work here is three-part:
1. Unmarshal support
2. Tests
3. Example

I ventured into deeper Golang areas here, so @alecthomas @mihai-chiorean @mistermoe any go-specific feedback on this PR would be much appreciated. Thanks!

Created new tickets for the other areas in the DID Document where mixed types exist
- https://github.com/TBD54566975/web5-go/issues/101
- https://github.com/TBD54566975/web5-go/issues/102
- https://github.com/TBD54566975/web5-go/issues/103