### PR TITLE
add DHT command line support

### DIFF
--- a/cmd/web5/README.md
+++ b/cmd/web5/README.md
@@ -43,5 +43,8 @@ Commands:
   vc jwt decode <jwt>
     Decode a VC-JWT.
 
+  did create dht
+    Create did:dht's using the default gateway.
+    
 Run "web5 <command> --help" for more information on a command.
 ```

--- a/cmd/web5/cmd_did_create.go
+++ b/cmd/web5/cmd_did_create.go
@@ -45,6 +45,7 @@ func (c *didCreateWebCMD) Run() error {
 }
 
 type didCreateDHTCMD struct {
+	NoIndent bool `help:"Print the portable DID without indentation." default:"false"`
 }
 
 func (c *didCreateDHTCMD) Run() error {
@@ -53,7 +54,7 @@ func (c *didCreateDHTCMD) Run() error {
 		return err
 	}
 
-	return printDID(did, false)
+	return printDID(did, c.NoIndent)
 }
 
 func printDID(d did.BearerDID, noIndent bool) error {

--- a/cmd/web5/cmd_did_create.go
+++ b/cmd/web5/cmd_did_create.go
@@ -1,9 +1,12 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
+	"github.com/tbd54566975/web5-go/dids/did"
+	"github.com/tbd54566975/web5-go/dids/diddht"
 	"github.com/tbd54566975/web5-go/dids/didjwk"
 	"github.com/tbd54566975/web5-go/dids/didweb"
 )
@@ -11,6 +14,7 @@ import (
 type didCreateCMD struct {
 	JWK didCreateJWKCMD `cmd:"" help:"Create a did:jwk."`
 	Web didCreateWebCMD `cmd:"" help:"Create a did:web."`
+	DHT didCreateDHTCMD `cmd:"" help:"Create a did:dht's."`
 }
 
 type didCreateJWKCMD struct {
@@ -23,25 +27,7 @@ func (c *didCreateJWKCMD) Run() error {
 		return err
 	}
 
-	portableDID, err := did.ToPortableDID()
-	if err != nil {
-		return err
-	}
-
-	var jsonDID []byte
-	if c.NoIndent {
-		jsonDID, err = json.Marshal(portableDID)
-	} else {
-		jsonDID, err = json.MarshalIndent(portableDID, "", "  ")
-	}
-
-	if err != nil {
-		return err
-	}
-
-	fmt.Println(string(jsonDID))
-
-	return nil
+	return printDID(did, c.NoIndent)
 }
 
 type didCreateWebCMD struct {
@@ -55,13 +41,29 @@ func (c *didCreateWebCMD) Run() error {
 		return err
 	}
 
-	portableDID, err := did.ToPortableDID()
+	return printDID(did, c.NoIndent)
+}
+
+type didCreateDHTCMD struct {
+}
+
+func (c *didCreateDHTCMD) Run() error {
+	did, err := diddht.CreateWithContext(context.Background())
+	if err != nil {
+		return err
+	}
+
+	return printDID(did, false)
+}
+
+func printDID(d did.BearerDID, noIndent bool) error {
+	portableDID, err := d.ToPortableDID()
 	if err != nil {
 		return err
 	}
 
 	var jsonDID []byte
-	if c.NoIndent {
+	if noIndent {
 		jsonDID, err = json.Marshal(portableDID)
 	} else {
 		jsonDID, err = json.MarshalIndent(portableDID, "", "  ")

--- a/cmd/web5/cmd_did_create.go
+++ b/cmd/web5/cmd_did_create.go
@@ -14,7 +14,7 @@ import (
 type didCreateCMD struct {
 	JWK didCreateJWKCMD `cmd:"" help:"Create a did:jwk."`
 	Web didCreateWebCMD `cmd:"" help:"Create a did:web."`
-	DHT didCreateDHTCMD `cmd:"" help:"Create a did:dht's."`
+	DHT didCreateDHTCMD `cmd:"" help:"Create a did:dht."`
 }
 
 type didCreateJWKCMD struct {

--- a/dids/diddht/diddht.go
+++ b/dids/diddht/diddht.go
@@ -19,6 +19,8 @@ import (
 	"github.com/tv42/zbase32"
 )
 
+const defaultGatewayURL = "https://diddht.tbddev.org"
+
 // gateway is the internal interface used to publish Pakrr messages to the DHT
 type gateway interface {
 	Put(didID string, payload *bep44.Message) error
@@ -34,7 +36,7 @@ var once sync.Once
 // getDefaultGateway returns the default Pkarr relay client.
 func getDefaultGateway() gateway {
 	once.Do(func() {
-		defaultGateway = pkarr.NewClient("", http.DefaultClient)
+		defaultGateway = pkarr.NewClient(defaultGatewayURL, http.DefaultClient)
 	})
 
 	return defaultGateway
@@ -130,7 +132,8 @@ func Gateway(gatewayURL string, client *http.Client) CreateOption {
 
 // Create creates a new `did:dht` DID and publishes it to the DHT network via a Pkarr gateway.
 //
-// If no gateway is passed in the options, Create uses a default Pkarr gateway.
+// If no gateway is passed in the options, Create uses a default Pkarr gateway. (https://diddht.tbddev.org)
+//
 // Spec: https://did-dht.com/#create
 func Create(opts ...CreateOption) (did.BearerDID, error) {
 	return CreateWithContext(context.Background(), opts...)

--- a/dids/diddht/internal/bencode/bencode.go
+++ b/dids/diddht/internal/bencode/bencode.go
@@ -51,7 +51,7 @@ func Marshal(input any) ([]byte, error) {
 		return b, nil
 	case map[string]any:
 		var b []byte
-		b = append(b, 'd')
+		// b = append(b, 'd')
 
 		for key, value := range v {
 			encodedKey, err := Marshal(key)
@@ -68,7 +68,7 @@ func Marshal(input any) ([]byte, error) {
 			b = append(b, encodedValue...)
 		}
 
-		b = append(b, 'e')
+		// b = append(b, 'e')
 
 		return b, nil
 	default:

--- a/dids/diddht/internal/bencode/bencode.go
+++ b/dids/diddht/internal/bencode/bencode.go
@@ -51,7 +51,7 @@ func Marshal(input any) ([]byte, error) {
 		return b, nil
 	case map[string]any:
 		var b []byte
-		// b = append(b, 'd')
+		b = append(b, 'd')
 
 		for key, value := range v {
 			encodedKey, err := Marshal(key)
@@ -68,7 +68,7 @@ func Marshal(input any) ([]byte, error) {
 			b = append(b, encodedValue...)
 		}
 
-		// b = append(b, 'e')
+		b = append(b, 'e')
 
 		return b, nil
 	default:

--- a/dids/diddht/internal/bep44/bep44_test.go
+++ b/dids/diddht/internal/bep44/bep44_test.go
@@ -3,11 +3,11 @@ package bep44
 import (
 	"crypto/ed25519"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/alecthomas/assert/v2"
-	"github.com/tbd54566975/web5-go/dids/diddht/internal/bencode"
 )
 
 func Test_newSignedBEP44Message(t *testing.T) {
@@ -57,14 +57,13 @@ func Test_newSignedBEP44Message(t *testing.T) {
 			}
 			assert.Equal(t, tt.args.publicKeyBytes, got.k)
 
-			bencoded := map[string]any{
-				"seq": got.Seq,
-				"v":   got.V,
-			}
-
-			bencodedBytes, err := bencode.Marshal(bencoded)
+			bencodedBytes, err := bencodeBepPayload(tt.args.seq, tt.args.payload)
 			assert.NoError(t, err)
-			assert.True(t, ed25519.Verify(tt.args.publicKeyBytes, bencodedBytes, got.sig))
+			verified := ed25519.Verify(tt.args.publicKeyBytes, bencodedBytes, got.sig)
+			if !verified {
+				fmt.Println(string(bencodedBytes), got.sig, tt)
+			}
+			assert.True(t, verified)
 		})
 	}
 }

--- a/dids/diddht/resolver.go
+++ b/dids/diddht/resolver.go
@@ -64,11 +64,8 @@ func (r *Resolver) ResolveWithContext(ctx context.Context, uri string) (didcore.
 		return didcore.ResolutionResultWithError("invalidDid"), didcore.ResolutionError{Code: "invalidDid"}
 	}
 
-	bep44MessagePayload, err := bep44Message.UnmarshalPayload()
-	if err != nil {
-		return didcore.ResolutionResultWithError("invalidDid"), didcore.ResolutionError{Code: "invalidDid"}
-	}
-
+	// get the dns payload from the bep44 message
+	bep44MessagePayload := bep44Message.V
 	document, err := dns.UnmarshalDIDDocument(bep44MessagePayload)
 	if err != nil {
 		// TODO log err


### PR DESCRIPTION

Bencoding is changed to use a string pattern instead, for a few reasons:
1. bencoding maps is non deterministic because we can't guarantee the order of the fields, which means the signature check fails
2. the bencoding standard wraps the map into starting with d and ending in e. to respect bep44 requirements, we need to remove the first and last byte
3. we only and always will have 2 fields here and bencoding results in a .. string. so, might as well use a string template to create the payload for signing