### PR TITLE
Add VC commands to web5 CLI

### DIFF
--- a/cmd/web5/README.md
+++ b/cmd/web5/README.md
@@ -24,6 +24,9 @@ Commands:
   vc create <credential-subject-id>
     Create a VC.
 
+  vc sign <vc> <portable-did>
+    Sign a VC.
+
   vc jwt verify <jwt>
     Verify a VC-JWT.
 

--- a/cmd/web5/README.md
+++ b/cmd/web5/README.md
@@ -16,10 +16,19 @@ Commands:
     Resolve a DID.
 
   did create jwk
-    Create did:jwk's.
+    Create a did:jwk.
 
   did create web <domain>
-    Create did:web's.
+    Create a did:web.
+
+  vc create <credential-subject-id>
+    Create a VC.
+
+  vc jwt verify <jwt>
+    Verify a VC-JWT.
+
+  vc jwt decode <jwt>
+    Decode a VC-JWT.
 
 Run "web5 <command> --help" for more information on a command.
 ```

--- a/cmd/web5/README.md
+++ b/cmd/web5/README.md
@@ -6,12 +6,22 @@
 ➜ web5 -h
 Usage: web5 <command>
 
-Web5 - A decentralized web platform that puts you in control of your data and identity.
+Web5 - A decentralized web platform that puts you in control of your
+data and identity.
 
 Flags:
   -h, --help    Show context-sensitive help.
 
 Commands:
+  jwt sign <claims> <portable-did>
+    Sign a JWT.
+
+  jwt decode <jwt>
+    Decode a JWT.
+
+  jwt verify <jwt>
+    Verify a JWT.
+
   did resolve <uri>
     Resolve a DID.
 

--- a/cmd/web5/cmd_did_create.go
+++ b/cmd/web5/cmd_did_create.go
@@ -13,7 +13,9 @@ type didCreateCMD struct {
 	Web didCreateWebCMD `cmd:"" help:"Create a did:web."`
 }
 
-type didCreateJWKCMD struct{}
+type didCreateJWKCMD struct {
+	NoIndent bool `help:"Print the portable DID without indentation." default:"false"`
+}
 
 func (c *didCreateJWKCMD) Run() error {
 	did, err := didjwk.Create()
@@ -26,7 +28,13 @@ func (c *didCreateJWKCMD) Run() error {
 		return err
 	}
 
-	jsonDID, err := json.MarshalIndent(portableDID, "", "  ")
+	var jsonDID []byte
+	if c.NoIndent {
+		jsonDID, err = json.Marshal(portableDID)
+	} else {
+		jsonDID, err = json.MarshalIndent(portableDID, "", "  ")
+	}
+
 	if err != nil {
 		return err
 	}
@@ -37,7 +45,8 @@ func (c *didCreateJWKCMD) Run() error {
 }
 
 type didCreateWebCMD struct {
-	Domain string `arg:"" help:"The domain name for the DID." required:""`
+	Domain   string `arg:"" help:"The domain name for the DID." required:""`
+	NoIndent bool   `help:"Print the portable DID without indentation." default:"false"`
 }
 
 func (c *didCreateWebCMD) Run() error {
@@ -51,7 +60,13 @@ func (c *didCreateWebCMD) Run() error {
 		return err
 	}
 
-	jsonDID, err := json.MarshalIndent(portableDID, "", "  ")
+	var jsonDID []byte
+	if c.NoIndent {
+		jsonDID, err = json.Marshal(portableDID)
+	} else {
+		jsonDID, err = json.MarshalIndent(portableDID, "", "  ")
+	}
+
 	if err != nil {
 		return err
 	}

--- a/cmd/web5/cmd_did_create.go
+++ b/cmd/web5/cmd_did_create.go
@@ -9,8 +9,8 @@ import (
 )
 
 type didCreateCMD struct {
-	JWK didCreateJWKCMD `cmd:"" help:"Create did:jwk's."`
-	Web didCreateWebCMD `cmd:"" help:"Create did:web's."`
+	JWK didCreateJWKCMD `cmd:"" help:"Create a did:jwk."`
+	Web didCreateWebCMD `cmd:"" help:"Create a did:web."`
 }
 
 type didCreateJWKCMD struct{}

--- a/cmd/web5/cmd_did_resolve.go
+++ b/cmd/web5/cmd_did_resolve.go
@@ -8,7 +8,8 @@ import (
 )
 
 type didResolveCMD struct {
-	URI string `arg:"" name:"uri" help:"The URI to resolve."`
+	URI      string `arg:"" name:"uri" help:"The URI to resolve."`
+	NoIndent bool   `help:"Print the DID Document without indentation." default:"false"`
 }
 
 func (c *didResolveCMD) Run() error {
@@ -17,12 +18,17 @@ func (c *didResolveCMD) Run() error {
 		return err
 	}
 
-	jsonDID, err := json.MarshalIndent(result.Document, "", "  ")
+	var jsonDIDDocument []byte
+	if c.NoIndent {
+		jsonDIDDocument, err = json.Marshal(result.Document)
+	} else {
+		jsonDIDDocument, err = json.MarshalIndent(result.Document, "", "  ")
+	}
 	if err != nil {
 		return err
 	}
 
-	fmt.Println(string(jsonDID))
+	fmt.Println(string(jsonDIDDocument))
 
 	return nil
 }

--- a/cmd/web5/cmd_jwt_decode.go
+++ b/cmd/web5/cmd_jwt_decode.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/tbd54566975/web5-go/jwt"
+)
+
+type jwtDecodeCMD struct {
+	JWT      string `arg:"" help:"The base64 encoded JWT"`
+	Claims   bool   `help:"Only print the JWT Claims." default:"false"`
+	NoIndent bool   `help:"Print the decoded VC-JWT without indentation." default:"false"`
+}
+
+func (c *jwtDecodeCMD) Run() error {
+	decoded, err := jwt.Decode(c.JWT)
+	if err != nil {
+		return err
+	}
+
+	var partToPrint any
+	if c.Claims {
+		partToPrint = decoded.Claims
+	} else {
+		partToPrint = decoded
+	}
+
+	var bytes []byte
+	if c.NoIndent {
+		bytes, err = json.Marshal(partToPrint)
+	} else {
+		bytes, err = json.MarshalIndent(partToPrint, "", "  ")
+	}
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(string(bytes))
+
+	return nil
+}

--- a/cmd/web5/cmd_jwt_sign.go
+++ b/cmd/web5/cmd_jwt_sign.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/tbd54566975/web5-go/dids/did"
+	"github.com/tbd54566975/web5-go/jwt"
+)
+
+type jwtSignCMD struct {
+	Claims      string `arg:"" help:"The JWT Claims. Value is a JSON string."`
+	PortableDID string `arg:"" help:"The Portable DID to sign with. Value is a JSON string."`
+	Purpose     string `help:"Used to specify which key from the given DID Document should be used."`
+	Type        string `help:"Used to set the JWS Header 'typ' property"`
+}
+
+func (c *jwtSignCMD) Run() error {
+	var claims jwt.Claims
+	err := json.Unmarshal([]byte(c.Claims), &claims)
+	if err != nil {
+		return fmt.Errorf("%s: %w", "invalid credential", err)
+	}
+
+	var portableDID did.PortableDID
+	err = json.Unmarshal([]byte(c.PortableDID), &portableDID)
+	if err != nil {
+		return fmt.Errorf("%s: %w", "invalid portable DID", err)
+	}
+
+	bearerDID, err := did.FromPortableDID(portableDID)
+	if err != nil {
+		return err
+	}
+
+	opts := []jwt.SignOpt{}
+	if c.Purpose != "" {
+		opts = append(opts, jwt.Purpose(c.Purpose))
+	}
+	if c.Type != "" {
+		opts = append(opts, jwt.Type(c.Type))
+	}
+
+	signed, err := jwt.Sign(claims, bearerDID, opts...)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(signed)
+
+	return nil
+}

--- a/cmd/web5/cmd_jwt_verify.go
+++ b/cmd/web5/cmd_jwt_verify.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/tbd54566975/web5-go/jwt"
+)
+
+type jwtVerifyCMD struct {
+	JWT      string `arg:"" help:"The base64 encoded JWT"`
+	Claims   bool   `help:"Only print the JWT Claims." default:"false"`
+	NoIndent bool   `help:"Print the decoded VC-JWT without indentation." default:"false"`
+}
+
+func (c *jwtVerifyCMD) Run() error {
+	decoded, err := jwt.Verify(c.JWT)
+	if err != nil {
+		return err
+	}
+
+	var partToPrint any
+	if c.Claims {
+		partToPrint = decoded.Claims
+	} else {
+		partToPrint = decoded
+	}
+
+	var bytes []byte
+	if c.NoIndent {
+		bytes, err = json.Marshal(partToPrint)
+	} else {
+		bytes, err = json.MarshalIndent(partToPrint, "", "  ")
+	}
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(string(bytes))
+
+	return nil
+}

--- a/cmd/web5/cmd_vc.go
+++ b/cmd/web5/cmd_vc.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/tbd54566975/web5-go/vc"
+)
+
+type vcCreateCMD struct {
+	CredentialSubjectID string    `arg:"" help:"The Credential Subject's ID"`
+	Claims              string    `help:"Add additional credentialSubject claims (JSON string). ex: '{\"name\": \"John Doe\"}'." default:"{}"`
+	Contexts            []string  `help:"Add additional @context's to the default [\"https://www.w3.org/2018/credentials/v1\"]."`
+	Types               []string  `help:"Add additional type's to the default [\"VerifiableCredential\"]."`
+	ID                  string    `help:"Override the default ID of format urn:vc:uuid:<uuid>."`
+	IssuanceDate        time.Time `help:"Override the default issuanceDate of time.Now()."`
+	ExpirationDate      time.Time `help:"Override the default expirationDate of nil."`
+}
+
+func (c *vcCreateCMD) Run() error {
+	opts := []vc.CreateOption{}
+	if len(c.Contexts) > 0 {
+		opts = append(opts, vc.Contexts(c.Contexts...))
+	}
+	if len(c.Types) > 0 {
+		opts = append(opts, vc.Types(c.Types...))
+	}
+	if c.ID != "" {
+		opts = append(opts, vc.ID(c.ID))
+	}
+	if (c.IssuanceDate != time.Time{}) {
+		opts = append(opts, vc.IssuanceDate(c.IssuanceDate))
+	}
+	if (c.ExpirationDate != time.Time{}) {
+		opts = append(opts, vc.ExpirationDate(c.ExpirationDate))
+	}
+
+	var claims vc.Claims
+	err := json.Unmarshal([]byte(c.Claims), &claims)
+	if err != nil {
+		return fmt.Errorf("%s: %w", "invalid claims", err)
+	}
+
+	claims["id"] = c.CredentialSubjectID
+
+	credential := vc.Create(claims, opts...)
+
+	jsonDID, err := json.MarshalIndent(credential, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(string(jsonDID))
+
+	return nil
+}

--- a/cmd/web5/cmd_vc_create.go
+++ b/cmd/web5/cmd_vc_create.go
@@ -18,8 +18,9 @@ type vcCreateCMD struct {
 	ID                  string    `help:"Override the default ID of format urn:vc:uuid:<uuid>."`
 	IssuanceDate        time.Time `help:"Override the default issuanceDate of time.Now()."`
 	ExpirationDate      time.Time `help:"Override the default expirationDate of nil."`
-	Sign                bool      `help:"Sign the VC with the provided --portable-did" default:"false"`
-	PortableDID         string    `help:"Portable DID used with --sign"`
+	Sign                bool      `help:"Sign the VC with the provided --portable-did." default:"false"`
+	PortableDID         string    `help:"Portable DID used with --sign. Value is a JSON string."`
+	NoIndent            bool      `help:"Print the VC without indentation." default:"false"`
 }
 
 func (c *vcCreateCMD) Run() error {
@@ -77,7 +78,12 @@ func (c *vcCreateCMD) Run() error {
 		return nil
 	}
 
-	jsonVC, err := json.MarshalIndent(credential, "", "  ")
+	var jsonVC []byte
+	if c.NoIndent {
+		jsonVC, err = json.Marshal(credential)
+	} else {
+		jsonVC, err = json.MarshalIndent(credential, "", "  ")
+	}
 	if err != nil {
 		return err
 	}

--- a/cmd/web5/cmd_vc_create.go
+++ b/cmd/web5/cmd_vc_create.go
@@ -77,12 +77,12 @@ func (c *vcCreateCMD) Run() error {
 		return nil
 	}
 
-	jsonDID, err := json.MarshalIndent(credential, "", "  ")
+	jsonVC, err := json.MarshalIndent(credential, "", "  ")
 	if err != nil {
 		return err
 	}
 
-	fmt.Println(string(jsonDID))
+	fmt.Println(string(jsonVC))
 
 	return nil
 }

--- a/cmd/web5/cmd_vc_jwt.go
+++ b/cmd/web5/cmd_vc_jwt.go
@@ -13,7 +13,8 @@ type vcJWTCMD struct {
 }
 
 type vcJWTVerifyCMD struct {
-	JWT string `arg:"" help:"The VC-JWT"`
+	JWT      string `arg:"" help:"The VC-JWT"`
+	NoIndent bool   `help:"Print the decoded VC-JWT without indentation." default:"false"`
 }
 
 func (c *vcJWTVerifyCMD) Run() error {
@@ -22,7 +23,12 @@ func (c *vcJWTVerifyCMD) Run() error {
 		return err
 	}
 
-	jsonVC, err := json.MarshalIndent(decoded.VC, "", "  ")
+	var jsonVC []byte
+	if c.NoIndent {
+		jsonVC, err = json.Marshal(decoded.VC)
+	} else {
+		jsonVC, err = json.MarshalIndent(decoded.VC, "", "  ")
+	}
 	if err != nil {
 		return err
 	}
@@ -33,7 +39,8 @@ func (c *vcJWTVerifyCMD) Run() error {
 }
 
 type vcJWTDecodeCMD struct {
-	JWT string `arg:"" help:"The VC-JWT"`
+	JWT      string `arg:"" help:"The VC-JWT"`
+	NoIndent bool   `help:"Print the decoded VC-JWT without indentation." default:"false"`
 }
 
 func (c *vcJWTDecodeCMD) Run() error {
@@ -42,7 +49,12 @@ func (c *vcJWTDecodeCMD) Run() error {
 		return err
 	}
 
-	jsonVC, err := json.MarshalIndent(decoded.VC, "", "  ")
+	var jsonVC []byte
+	if c.NoIndent {
+		jsonVC, err = json.Marshal(decoded.VC)
+	} else {
+		jsonVC, err = json.MarshalIndent(decoded.VC, "", "  ")
+	}
 	if err != nil {
 		return err
 	}

--- a/cmd/web5/cmd_vc_jwt.go
+++ b/cmd/web5/cmd_vc_jwt.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/tbd54566975/web5-go/vc"
+)
+
+type vcJWTCMD struct {
+	Verify vcJWTVerifyCMD `cmd:"" help:"Verify a VC-JWT."`
+	Decode vcJWTDecodeCMD `cmd:"" help:"Decode a VC-JWT."`
+}
+
+type vcJWTVerifyCMD struct {
+	JWT string `arg:"" help:"The VC-JWT"`
+}
+
+func (c *vcJWTVerifyCMD) Run() error {
+	decoded, err := vc.Verify[vc.Claims](c.JWT)
+	if err != nil {
+		return err
+	}
+
+	jsonVC, err := json.MarshalIndent(decoded.VC, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(string(jsonVC))
+
+	return nil
+}
+
+type vcJWTDecodeCMD struct {
+	JWT string `arg:"" help:"The VC-JWT"`
+}
+
+func (c *vcJWTDecodeCMD) Run() error {
+	decoded, err := vc.Decode[vc.Claims](c.JWT)
+	if err != nil {
+		return err
+	}
+
+	jsonVC, err := json.MarshalIndent(decoded.VC, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(string(jsonVC))
+
+	return nil
+}

--- a/cmd/web5/cmd_vc_sign.go
+++ b/cmd/web5/cmd_vc_sign.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/tbd54566975/web5-go/dids/did"
+	"github.com/tbd54566975/web5-go/vc"
+)
+
+type vcSignCMD struct {
+	VC          string `arg:"" help:"The VC to sign. Value is a JSON string."`
+	PortableDID string `arg:"" help:"The Portable DID to sign with. Value is a JSON string."`
+}
+
+func (c *vcSignCMD) Run() error {
+	var credential vc.DataModel[vc.Claims]
+	err := json.Unmarshal([]byte(c.VC), &credential)
+	if err != nil {
+		return fmt.Errorf("%s: %w", "invalid credential", err)
+	}
+
+	var portableDID did.PortableDID
+	err = json.Unmarshal([]byte(c.PortableDID), &portableDID)
+	if err != nil {
+		return fmt.Errorf("%s: %w", "invalid portable DID", err)
+	}
+
+	bearerDID, err := did.FromPortableDID(portableDID)
+	if err != nil {
+		return err
+	}
+
+	// TODO sign opts
+	signed, err := credential.Sign(bearerDID)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(signed)
+
+	return nil
+}

--- a/cmd/web5/main.go
+++ b/cmd/web5/main.go
@@ -15,6 +15,9 @@ type CLI struct {
 		Resolve didResolveCMD `cmd:"" help:"Resolve a DID."`
 		Create  didCreateCMD  `cmd:"" help:"Create a DID."`
 	} `cmd:"" help:"Interface with DID's."`
+	VC struct {
+		Create vcCreateCMD `cmd:"" help:"Create a VC."`
+	} `cmd:"" help:"Interface with VC's."`
 }
 
 func main() {

--- a/cmd/web5/main.go
+++ b/cmd/web5/main.go
@@ -11,6 +11,11 @@ import (
 //
 // [kong documentation]: https://github.com/alecthomas/kong
 type CLI struct {
+	JWT struct {
+		Sign   jwtSignCMD   `cmd:"" help:"Sign a JWT."`
+		Decode jwtDecodeCMD `cmd:"" help:"Decode a JWT."`
+		Verify jwtVerifyCMD `cmd:"" help:"Verify a JWT."`
+	} `cmd:"" help:"Interface with JWT's."`
 	DID struct {
 		Resolve didResolveCMD `cmd:"" help:"Resolve a DID."`
 		Create  didCreateCMD  `cmd:"" help:"Create a DID."`

--- a/cmd/web5/main.go
+++ b/cmd/web5/main.go
@@ -17,6 +17,7 @@ type CLI struct {
 	} `cmd:"" help:"Interface with DID's."`
 	VC struct {
 		Create vcCreateCMD `cmd:"" help:"Create a VC."`
+		Sign   vcSignCMD   `cmd:"" help:"Sign a VC."`
 		JWT    vcJWTCMD    `cmd:"" help:"Tooling for VC-JWT's"`
 	} `cmd:"" help:"Interface with VC's."`
 }

--- a/cmd/web5/main.go
+++ b/cmd/web5/main.go
@@ -17,6 +17,7 @@ type CLI struct {
 	} `cmd:"" help:"Interface with DID's."`
 	VC struct {
 		Create vcCreateCMD `cmd:"" help:"Create a VC."`
+		JWT    vcJWTCMD    `cmd:"" help:"Tooling for VC-JWT's"`
 	} `cmd:"" help:"Interface with VC's."`
 }
 


### PR DESCRIPTION
Four new command interfaces for the web5 CLI

- `web5 vc create`
- `web5 vc sign`
- `web5 vc jwt verify`
- `web5 vc jwt decode`

Also added `--no-indent` flag to the `web5 did create` commands, which partially addresses https://github.com/TBD54566975/web5-go/issues/64 (will leave that open for the other part of that issue), and the `web5 did resolve` command.

---

Created two additional work items from this

- https://github.com/TBD54566975/web5-go/issues/111
- https://github.com/TBD54566975/web5-go/issues/112
