### PR TITLE
Standardize DID types & add did:jwk test vector

### DIFF
--- a/dids/didcore/document.go
+++ b/dids/didcore/document.go
@@ -27,7 +27,7 @@ const (
 // A DID Document can be retrieved by resolving a DID URI.
 type Document struct {
 	// Context is a URI that defines the schema version used in the document.
-	Context string `json:"@context,omitempty"`
+	Context []string `json:"@context,omitempty"`
 
 	// Id is the DID URI for a particular DID subject, expressed using the id property in the DID document.
 	ID string `json:"id"`
@@ -39,7 +39,6 @@ type Document struct {
 	// Controller defines an entity that is authorized to make changes to a DID document.
 	// The process of authorizing a DID controller is defined by the DID method.
 	// It can be a string or a list of strings.
-	// TODO: figure out how to handle string or list of strings
 	Controller []string `json:"controller,omitempty"`
 
 	// VerificationMethod is a list of cryptographic public keys, which can be used to authenticate or authorize
@@ -248,7 +247,7 @@ type DocumentMetadata struct {
 	// In this case, the DID method specification might need to express one or
 	// more DIDs that are logically equivalent to the resolved DID as a property
 	// of the DID document. This is the purpose of the equivalentId property.
-	EquivalentID string `json:"equivalentId,omitempty"`
+	EquivalentID []string `json:"equivalentId,omitempty"`
 	// The canonicalId property is identical to the equivalentId property except:
 	//   * it is associated with a single value rather than a set
 	//   * the DID is defined to be the canonical ID for the DID subject within
@@ -274,7 +273,7 @@ type Service struct {
 
 	// ServiceEndpoint is a network address, such as an HTTP URL, at which services
 	// operate on behalf of a DID subject.
-	ServiceEndpoint string `json:"serviceEndpoint"`
+	ServiceEndpoint []string `json:"serviceEndpoint"`
 }
 
 // VerificationMethod expresses verification methods, such as cryptographic

--- a/dids/didcore/document_test.go
+++ b/dids/didcore/document_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestAddVerificationMethod(t *testing.T) {
 	doc := didcore.Document{
-		Context: "https://www.w3.org/ns/did/v1",
+		Context: []string{"https://www.w3.org/ns/did/v1"},
 		ID:      "did:example:123456789abcdefghi",
 	}
 

--- a/dids/diddht/diddht.go
+++ b/dids/diddht/diddht.go
@@ -65,7 +65,7 @@ type verificationMethodOption struct {
 
 // Service is used to add a service to the DID being created with the [Create] function.
 // Note: Service can be passed to [Create] multiple times to add multiple services.
-func Service(id string, svcType string, endpoint []string) CreateOption {
+func Service(id string, svcType string, endpoint ...string) CreateOption {
 	return func(o *createOptions) {
 		// ensure that id follows relative DID URL requirements defined in did core spec:
 		// https://www.w3.org/TR/did-core/#relative-did-urls

--- a/dids/diddht/diddht.go
+++ b/dids/diddht/diddht.go
@@ -65,7 +65,7 @@ type verificationMethodOption struct {
 
 // Service is used to add a service to the DID being created with the [Create] function.
 // Note: Service can be passed to [Create] multiple times to add multiple services.
-func Service(id string, svcType string, endpoint string) CreateOption {
+func Service(id string, svcType string, endpoint []string) CreateOption {
 	return func(o *createOptions) {
 		// ensure that id follows relative DID URL requirements defined in did core spec:
 		// https://www.w3.org/TR/did-core/#relative-did-urls
@@ -188,6 +188,7 @@ func CreateWithContext(ctx context.Context, opts ...CreateOption) (did.BearerDID
 	}
 
 	document := didcore.Document{
+		Context:            []string{"https://www.w3.org/ns/did/v1"},
 		ID:                 bdid.URI,
 		Service:            []*didcore.Service{},
 		VerificationMethod: []didcore.VerificationMethod{},

--- a/dids/diddht/diddht_test.go
+++ b/dids/diddht/diddht_test.go
@@ -254,7 +254,7 @@ func Test_Create(t *testing.T) {
 			var opts []CreateOption
 			opts = []CreateOption{Gateway(relay.URL, http.DefaultClient), KeyManager(keyMgr)}
 			for _, service := range didDoc.Service {
-				opts = append(opts, Service(service.ID, service.Type, service.ServiceEndpoint))
+				opts = append(opts, Service(service.ID, service.Type, service.ServiceEndpoint...))
 			}
 			for _, key := range test.keys {
 				opts = append(opts, PrivateKey(key.algorithmID, key.purposes...))

--- a/dids/diddht/diddht_test.go
+++ b/dids/diddht/diddht_test.go
@@ -200,7 +200,7 @@ func Test_Create(t *testing.T) {
 				  {
 					"id": "did:dht:1wiaaaoagzceggsnwfzmx5cweog5msg4u536mby8sqy3mkp3wyko#dwn",
 					"type": "DecentralizedWebNode",
-					"serviceEndpoint": "https://example.com/dwn"
+					"serviceEndpoint": ["https://example.com/dwn1", "https://example.com/dwn2"]
 				  }
 				],
 				"authentication": [

--- a/dids/diddht/internal/dns/did.go
+++ b/dids/diddht/internal/dns/did.go
@@ -159,7 +159,7 @@ func MarshalVerificationMethod(vm *didcore.VerificationMethod) (string, error) {
 
 // MarshalService packs a service into a TXT DNS resource record and adds to the DNS message Answers
 func MarshalService(dhtDNSkey string, s *didcore.Service, msg *dnsmessage.Message) error {
-	rawData := fmt.Sprintf("id=%s;t=%s;se=%s", s.ID, s.Type, s.ServiceEndpoint)
+	rawData := fmt.Sprintf("id=%s;t=%s;se=%s", s.ID, s.Type, strings.Join(s.ServiceEndpoint, ","))
 
 	resource, err := newResource(fmt.Sprintf("_%s._did.", dhtDNSkey), rawData)
 	if err != nil {

--- a/dids/diddht/internal/dns/did.go
+++ b/dids/diddht/internal/dns/did.go
@@ -245,7 +245,7 @@ func UnmarshalService(data string, s *didcore.Service) error {
 				}
 				validEndpoints = append(validEndpoints, uri)
 			}
-			s.ServiceEndpoint = strings.Join(validEndpoints, ",")
+			s.ServiceEndpoint = validEndpoints
 		default:
 			continue
 		}

--- a/dids/didjwk/didjwk.go
+++ b/dids/didjwk/didjwk.go
@@ -121,7 +121,7 @@ func (r Resolver) Resolve(uri string) (didcore.ResolutionResult, error) {
 
 func createDocument(did did.DID, publicKey jwk.JWK) didcore.Document {
 	doc := didcore.Document{
-		Context: "https://www.w3.org/ns/did/v1",
+		Context: []string{"https://www.w3.org/ns/did/v1"},
 		ID:      did.URI,
 	}
 

--- a/dids/didjwk/didjwk_test.go
+++ b/dids/didjwk/didjwk_test.go
@@ -1,9 +1,11 @@
 package didjwk_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/alecthomas/assert/v2"
+	"github.com/tbd54566975/web5-go"
 	"github.com/tbd54566975/web5-go/dids/didcore"
 	"github.com/tbd54566975/web5-go/dids/didjwk"
 	"github.com/tbd54566975/web5-go/jwk"
@@ -33,4 +35,28 @@ func TestResolveDIDJWK(t *testing.T) {
 
 	assert.Equal(t, 1, len(result.Document.Authentication))
 	assert.Equal(t, 1, len(result.Document.AssertionMethod))
+}
+
+func TestVector_Resolve(t *testing.T) {
+	testVectors, err :=
+		web5.LoadTestVectors[string, didcore.ResolutionResult]("../../web5-spec/test-vectors/did_jwk/resolve.json")
+	assert.NoError(t, err)
+	fmt.Println("Running test vectors: ", testVectors.Description)
+
+	resolver := didjwk.Resolver{}
+
+	for _, vector := range testVectors.Vectors {
+		t.Run(vector.Description, func(t *testing.T) {
+			fmt.Println("Running test vector: ", vector.Description)
+
+			result, err := resolver.Resolve(vector.Input)
+
+			if vector.Errors {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, vector.Output, result)
+			}
+		})
+	}
 }

--- a/dids/didweb/didweb.go
+++ b/dids/didweb/didweb.go
@@ -48,7 +48,7 @@ func Service(id string, svcType string, endpoint string) CreateOption {
 			svcID = "#" + id
 		}
 
-		svc := didcore.Service{ID: svcID, Type: svcType, ServiceEndpoint: endpoint}
+		svc := didcore.Service{ID: svcID, Type: svcType, ServiceEndpoint: []string{endpoint}}
 		if o.services == nil {
 			o.services = make([]didcore.Service, 0)
 		}

--- a/dids/didweb/didweb_test.go
+++ b/dids/didweb/didweb_test.go
@@ -39,13 +39,13 @@ func TestCreate_WithOptions(t *testing.T) {
 	assert.NotEqual(t, didcore.Service{}, *pfisvc)
 	assert.Equal(t, "#pfi", pfisvc.ID)
 	assert.Equal(t, "PFI", pfisvc.Type)
-	assert.Equal(t, "http://localhost:8080/tbdex", pfisvc.ServiceEndpoint)
+	assert.Equal(t, "http://localhost:8080/tbdex", pfisvc.ServiceEndpoint[0])
 
 	idvsvc := document.Service[1]
 	assert.NotEqual(t, didcore.Service{}, *idvsvc)
 	assert.Equal(t, "#idv", idvsvc.ID)
 	assert.Equal(t, "IDV", idvsvc.Type)
-	assert.Equal(t, "http://localhost:8080/idv", idvsvc.ServiceEndpoint)
+	assert.Equal(t, "http://localhost:8080/idv", idvsvc.ServiceEndpoint[0])
 
 	assert.Equal(t, "did:example:123", document.AlsoKnownAs[0])
 	assert.Equal(t, "did:example:123", document.Controller[0])


### PR DESCRIPTION
This PR addresses the DID part of https://github.com/TBD54566975/web5-go/issues/109 I will follow-up with the VC part.

Narrowing the scope of this PR to strictly DIDs — will do VCs in a follow up. I debated writing custom json marshalling functions to enforce existence of required properties, but instead I think it would be better to integrate with the JSON Schemas for this feature — [created a ticket for this follow up work](https://github.com/TBD54566975/web5-go/issues/131).

I’ve also added test vector support for did:jwk which tests the latest requirements as the test vectors are up to date. I considered adding did:web, but we should add bring-your-own-client feature first so that we can mock the network integration.

I also realized we're not fully conformant to our resolution error types so I opened a new ticket for that as well https://github.com/TBD54566975/web5-go/issues/132