### PR TITLE
Move from JsonWebKey2020 to JsonWebKey for DID VMs

### DIFF
--- a/dids/didjwk/didjwk.go
+++ b/dids/didjwk/didjwk.go
@@ -127,7 +127,7 @@ func createDocument(did did.DID, publicKey jwk.JWK) didcore.Document {
 
 	vm := didcore.VerificationMethod{
 		ID:           did.URI + "#0",
-		Type:         "JsonWebKey2020",
+		Type:         "JsonWebKey",
 		Controller:   did.URI,
 		PublicKeyJwk: &publicKey,
 	}

--- a/dids/didweb/didweb.go
+++ b/dids/didweb/didweb.go
@@ -167,7 +167,7 @@ func Create(domain string, opts ...CreateOption) (_did.BearerDID, error) {
 
 		vm := didcore.VerificationMethod{
 			ID:           "#" + strconv.Itoa(idx),
-			Type:         "JsonWebKey2020",
+			Type:         "JsonWebKey",
 			Controller:   did.URI,
 			PublicKeyJwk: &publicKeyJWK,
 		}


### PR DESCRIPTION
We're standardizing web5 SDKs to using `JsonWebKey` as our DID VM types; this is only applicable to DID Creation, as DID resolution will still support `JsonWebKey2020`