### PR TITLE
Detached jws verification

### DIFF
--- a/jws/jws_test.go
+++ b/jws/jws_test.go
@@ -159,3 +159,18 @@ func TestVerify(t *testing.T) {
 	_, err = jws.Verify(compactJWS)
 	assert.NoError(t, err)
 }
+
+func TestVerify_Detached(t *testing.T) {
+	did, err := didjwk.Create()
+	assert.NoError(t, err)
+
+	payload := []byte("hi")
+
+	compactJWS, err := jws.Sign(payload, did, jws.DetachedPayload(true))
+	assert.NoError(t, err)
+
+	decoded, err := jws.Verify(compactJWS, jws.Payload(payload))
+	assert.NoError(t, err)
+
+	assert.Equal(t, payload, decoded.Payload)
+}

--- a/vc/vcjwt_test.go
+++ b/vc/vcjwt_test.go
@@ -1,7 +1,6 @@
 package vc_test
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
@@ -158,10 +157,8 @@ func TestVerify(t *testing.T) {
 			_, err := vc.Verify[vc.Claims](tt.input)
 
 			if tt.errors == true {
-				fmt.Printf("true error: %v\n", err)
 				assert.Error(t, err)
 			} else {
-				fmt.Printf("false error: %v\n", err)
 				assert.NoError(t, err)
 			}
 		})


### PR DESCRIPTION
# Summary
Includes ability to verify a compact JWS with [detached content](https://datatracker.ietf.org/doc/html/rfc7515#appendix-F)