### PR TITLE
Remove redundant CLI argument for vc create --sign

### DIFF
--- a/cmd/web5/cmd_vc_create.go
+++ b/cmd/web5/cmd_vc_create.go
@@ -17,7 +17,7 @@ type vcCreateCMD struct {
 	ID                  string    `help:"Override the default ID of format urn:vc:uuid:<uuid>."`
 	IssuanceDate        time.Time `help:"Override the default issuanceDate of time.Now()."`
 	ExpirationDate      time.Time `help:"Override the default expirationDate of nil."`
-	Sign                string    `help:"Portable DID used with --sign. Value is a JSON string."`
+	Sign                string    `help:"Portable DID used to sign the VC-JWT. Value is a JSON string."`
 	NoIndent            bool      `help:"Print the VC without indentation." default:"false"`
 }
 

--- a/cmd/web5/cmd_vc_create.go
+++ b/cmd/web5/cmd_vc_create.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"time"
 
@@ -18,8 +17,7 @@ type vcCreateCMD struct {
 	ID                  string    `help:"Override the default ID of format urn:vc:uuid:<uuid>."`
 	IssuanceDate        time.Time `help:"Override the default issuanceDate of time.Now()."`
 	ExpirationDate      time.Time `help:"Override the default expirationDate of nil."`
-	Sign                bool      `help:"Sign the VC with the provided --portable-did." default:"false"`
-	PortableDID         string    `help:"Portable DID used with --sign. Value is a JSON string."`
+	Sign                string    `help:"Portable DID used with --sign. Value is a JSON string."`
 	NoIndent            bool      `help:"Print the VC without indentation." default:"false"`
 }
 
@@ -51,13 +49,9 @@ func (c *vcCreateCMD) Run() error {
 
 	credential := vc.Create(claims, opts...)
 
-	if c.Sign {
-		if c.PortableDID == "" {
-			return errors.New("--portable-did must be provided with --sign")
-		}
-
+	if c.Sign != "" {
 		var portableDID did.PortableDID
-		err = json.Unmarshal([]byte(c.PortableDID), &portableDID)
+		err = json.Unmarshal([]byte(c.Sign), &portableDID)
 		if err != nil {
 			return fmt.Errorf("%s: %w", "invalid portable DID", err)
 		}


### PR DESCRIPTION
We use to have to go something like `web5 vc create <id> --sign --portable-did <portable did>` but the `--sign` and `--portable-did` are redundant. So now it's just `web5 vc create <id> --sign <portable did>` (removed `--portable-did`)

Example:

```shell
web5-go on  main [$!] via 🐹 v1.22.0
➜ web5 vc create testing123 --sign '{"uri":"did:jwk:eyJrdHkiOiJPS1AiLCJjcnYiOiJFZDI1NTE5IiwieCI6Il9EZ3p1cHNRb3h6YWlUNG9mYmprLUpkS1hLamJldlNnc05DWlVfWFpLdjAifQ","privateKeys":[{"kty":"OKP","crv":"Ed25519","d":"MBCR01OIBKA_XFSpI55CH2v-HdZb-GWeDPwWKChnq_v8ODO6mxCjHNqJPih9uOT4l0pcqNt69KCw0JlT9dkq_Q","x":"_DgzupsQoxzaiT4ofbjk-JdKXKjbevSgsNCZU_XZKv0"}],"document":{"@context":"https://www.w3.org/ns/did/v1","id":"did:jwk:eyJrdHkiOiJPS1AiLCJjcnYiOiJFZDI1NTE5IiwieCI6Il9EZ3p1cHNRb3h6YWlUNG9mYmprLUpkS1hLamJldlNnc05DWlVfWFpLdjAifQ","verificationMethod":[{"id":"did:jwk:eyJrdHkiOiJPS1AiLCJjcnYiOiJFZDI1NTE5IiwieCI6Il9EZ3p1cHNRb3h6YWlUNG9mYmprLUpkS1hLamJldlNnc05DWlVfWFpLdjAifQ#0","type":"JsonWebKey2020","controller":"did:jwk:eyJrdHkiOiJPS1AiLCJjcnYiOiJFZDI1NTE5IiwieCI6Il9EZ3p1cHNRb3h6YWlUNG9mYmprLUpkS1hLamJldlNnc05DWlVfWFpLdjAifQ","publicKeyJwk":{"kty":"OKP","crv":"Ed25519","x":"_DgzupsQoxzaiT4ofbjk-JdKXKjbevSgsNCZU_XZKv0"}}],"assertionMethod":["did:jwk:eyJrdHkiOiJPS1AiLCJjcnYiOiJFZDI1NTE5IiwieCI6Il9EZ3p1cHNRb3h6YWlUNG9mYmprLUpkS1hLamJldlNnc05DWlVfWFpLdjAifQ#0"],"authentication":["did:jwk:eyJrdHkiOiJPS1AiLCJjcnYiOiJFZDI1NTE5IiwieCI6Il9EZ3p1cHNRb3h6YWlUNG9mYmprLUpkS1hLamJldlNnc05DWlVfWFpLdjAifQ#0"],"capabilityDelegation":["did:jwk:eyJrdHkiOiJPS1AiLCJjcnYiOiJFZDI1NTE5IiwieCI6Il9EZ3p1cHNRb3h6YWlUNG9mYmprLUpkS1hLamJldlNnc05DWlVfWFpLdjAifQ#0"],"capabilityInvocation":["did:jwk:eyJrdHkiOiJPS1AiLCJjcnYiOiJFZDI1NTE5IiwieCI6Il9EZ3p1cHNRb3h6YWlUNG9mYmprLUpkS1hLamJldlNnc05DWlVfWFpLdjAifQ#0"]},"metadata":null}'
eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDpqd2s6ZXlKcmRIa2lPaUpQUzFBaUxDSmpjbllpT2lKRlpESTFOVEU1SWl3aWVDSTZJbDlFWjNwMWNITlJiM2g2WVdsVU5HOW1ZbXByTFVwa1MxaExhbUpsZGxObmMwNURXbFZmV0ZwTGRqQWlmUSMwIiwidHlwIjoiSldUIn0.eyJpc3MiOiJkaWQ6andrOmV5SnJkSGtpT2lKUFMxQWlMQ0pqY25ZaU9pSkZaREkxTlRFNUlpd2llQ0k2SWw5RVozcDFjSE5SYjNoNllXbFVORzltWW1wckxVcGtTMWhMYW1KbGRsTm5jMDVEV2xWZldGcExkakFpZlEiLCJqdGkiOiJ1cm46dmM6dXVpZDo3NzBhNDMzMi03NTUxLTQ5NDktYmFmOC0xYzJmNWY2MGIwZDgiLCJuYmYiOjE3MTE2NTA5ODYsInN1YiI6InRlc3RpbmcxMjMiLCJ2YyI6eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvMjAxOC9jcmVkZW50aWFscy92MSJdLCJ0eXBlIjpbIlZlcmlmaWFibGVDcmVkZW50aWFsIl0sImlzc3VlciI6ImRpZDpqd2s6ZXlKcmRIa2lPaUpQUzFBaUxDSmpjbllpT2lKRlpESTFOVEU1SWl3aWVDSTZJbDlFWjNwMWNITlJiM2g2WVdsVU5HOW1ZbXByTFVwa1MxaExhbUpsZGxObmMwNURXbFZmV0ZwTGRqQWlmUSIsImNyZWRlbnRpYWxTdWJqZWN0Ijp7ImlkIjoidGVzdGluZzEyMyJ9LCJpZCI6InVybjp2Yzp1dWlkOjc3MGE0MzMyLTc1NTEtNDk0OS1iYWY4LTFjMmY1ZjYwYjBkOCIsImlzc3VhbmNlRGF0ZSI6IjIwMjQtMDMtMjhUMTg6MzY6MjZaIn19.WC93NiOdBRpUkuBTY0dTpXf2TK1F2-MQ-DkARE4Z665NNmWG1ubZ2dJeaC7WSk8jpK4YCqTmplkcFivu4RqUBQ
```