### PR TITLE
Bare minimum presentation definition types

### DIFF
--- a/pexv2/pd.go
+++ b/pexv2/pd.go
@@ -5,7 +5,7 @@ package pexv2
 //
 // [here]: https://identity.foundation/presentation-exchange/#presentation-definition
 type PresentationDefinition struct {
-	ID               string            `json:"id,omitempty"`
+	ID               string            `json:"id"`
 	Name             string            `json:"name,omitempty"`
 	Purpose          string            `json:"purpose,omitempty"`
 	Format           string            `json:"format,omitempty"`

--- a/pexv2/pd.go
+++ b/pexv2/pd.go
@@ -8,7 +8,6 @@ type PresentationDefinition struct {
 	ID               string            `json:"id"`
 	Name             string            `json:"name,omitempty"`
 	Purpose          string            `json:"purpose,omitempty"`
-	Format           string            `json:"format,omitempty"`
 	InputDescriptors []InputDescriptor `json:"input_descriptors"`
 }
 

--- a/pexv2/pd.go
+++ b/pexv2/pd.go
@@ -1,0 +1,46 @@
+package pexv2
+
+// PresentationDefinition represents a DIF Presentation Definition defined [here].
+// Presentation Definitions are objects that articulate what proofs a Verifier requires
+//
+// [here]: https://identity.foundation/presentation-exchange/#presentation-definition
+type PresentationDefinition struct {
+	ID               string            `json:"id,omitempty"`
+	Name             string            `json:"name,omitempty"`
+	Purpose          string            `json:"purpose,omitempty"`
+	Format           string            `json:"format,omitempty"`
+	InputDescriptors []InputDescriptor `json:"input_descriptors"`
+}
+
+// InputDescriptor represents a DIF Input Descriptor defined [here].
+// Input Descriptors are used to describe the information a Verifier requires of a Holder.
+//
+// [here]: https://identity.foundation/presentation-exchange/#input-descriptor
+type InputDescriptor struct {
+	ID          string      `json:"id"`
+	Name        string      `json:"name,omitempty"`
+	Purpose     string      `json:"purpose,omitempty"`
+	Constraints Constraints `json:"constraints"`
+}
+
+// Constraints contains the requirements for a given Input Descriptor.
+type Constraints struct {
+	Fields []Field `json:"fields,omitempty"`
+}
+
+// Field contains the requirements for a given field within a proof
+type Field struct {
+	ID      string   `json:"id,omitempty"`
+	Name    string   `json:"name,omitempty"`
+	Path    []string `json:"path,omitempty"`
+	Purpose string   `json:"purpose,omitempty"`
+	Filter  Filter   `json:"filter,omitempty"`
+}
+
+// Filter is a JSON Schema that is applied against the value of a field.
+type Filter struct {
+	Type     string  `json:"type,omitempty"`
+	Pattern  string  `json:"pattern,omitempty"`
+	Const    string  `json:"const,omitempty"`
+	Contains *Filter `json:"contains,omitempty"`
+}

--- a/vc/vc_test.go
+++ b/vc/vc_test.go
@@ -41,6 +41,7 @@ func TestCreate_Options(t *testing.T) {
 		vc.Types("StreetCredential"),
 		vc.IssuanceDate(issuanceDate),
 		vc.ExpirationDate(expirationDate),
+		vc.Schemas("https://example.org/examples/degree.json"),
 	)
 
 	assert.Equal(t, 2, len(cred.Context))
@@ -54,6 +55,11 @@ func TestCreate_Options(t *testing.T) {
 	assert.Equal(t, "hehecustomid", cred.ID)
 
 	assert.NotZero(t, cred.ExpirationDate)
+
+	assert.Equal(t, 1, len(cred.CredentialSchema))
+	assert.Equal(t, "https://example.org/examples/degree.json", cred.CredentialSchema[0].ID)
+	assert.Equal(t, "JsonSchema", cred.CredentialSchema[0].Type)
+
 }
 
 func TestSign(t *testing.T) {


### PR DESCRIPTION
# Changes

Added bare minimum [presentation definition](https://identity.foundation/presentation-exchange/#presentation-definition) types needed for tbdex

#### Usage

```go
pd := PresentationDefinition{
    InputDescriptors: []InputDescriptor{
        {
            Constraints: Constraints{
                Fields: []Field{
                    {
                        Path: []string{"$.credentialSchema[*].id"},
                        Filter: Filter{
                            Type:  "string",
                            Const: "https://schemas.tbdex.dev/KnownCustomerCredential"
                            
                        },
                    },
                    {
                        Path: []string{"$.issuer"},
                        Filter: Filter{
                            Type:  "string",
                            Const: "PFI_DID",
                        },
                    },
                },
            },
        },
    },
}
```

---

Added [`vc.credentialSchema`](https://www.w3.org/TR/vc-data-model-2.0/#data-schemas) and respective create option

> [!NOTE] 
> currently defaults `credentialSchema.type` to `JsonSchema`

> [!IMPORTANT]
> validation using these JSON Schemas will be added in a subsequent PR

#### Usage
```go
claims := vc.Claims{"id": "1234"}
issuanceDate := time.Now().UTC().Add(10 * time.Hour)
expirationDate := issuanceDate.Add(30 * time.Hour)

cred := vc.Create(
    claims,
    vc.ID("hehecustomid"),
    vc.Contexts("https://nocontextisbestcontext.gov"),
    vc.Types("StreetCredential"),
    vc.IssuanceDate(issuanceDate),
    vc.ExpirationDate(expirationDate),
    vc.Schemas("https://example.org/examples/degree.json"),
)
```