### PR TITLE
set `bearerDID.keyManager` in `diddht.Create`

### DIFF
--- a/dids/diddht/diddht.go
+++ b/dids/diddht/diddht.go
@@ -185,6 +185,7 @@ func CreateWithContext(ctx context.Context, opts ...CreateOption) (did.BearerDID
 			URI:    "did:dht:" + zbase32Encoded,
 			ID:     zbase32Encoded,
 		},
+		KeyManager: keyMgr,
 	}
 
 	document := didcore.Document{

--- a/dids/diddht/diddht_test.go
+++ b/dids/diddht/diddht_test.go
@@ -165,7 +165,7 @@ func TestDHTResolve(t *testing.T) {
 	}
 }
 
-func Test_Create(t *testing.T) {
+func TestCreate(t *testing.T) {
 	tests := map[string]struct {
 		didURI         string
 		expectedResult string
@@ -262,6 +262,7 @@ func Test_Create(t *testing.T) {
 
 			createdDid, err := Create(opts...)
 			assert.NoError(t, err)
+			assert.NotZero(t, createdDid.KeyManager)
 			resolver := NewResolver(relay.URL, http.DefaultClient)
 			result, err := resolver.Resolve(createdDid.URI)
 			assert.Equal(t, len(createdDid.Document.VerificationMethod), 2)

--- a/dids/diddht/internal/pkarr/gateway.go
+++ b/dids/diddht/internal/pkarr/gateway.go
@@ -45,7 +45,6 @@ func (r *Client) PutWithContext(ctx context.Context, didID string, msg *bep44.Me
 		return err
 	}
 
-	fmt.Println("Publishing to pkarr: pkarrURL", pkarrURL)
 	// Serialize the BEP44 message to a byte slice.
 	body, err := msg.Marshal()
 	if err != nil {


### PR DESCRIPTION
`keyManager` was not being set on the `BearerDID` returned by `diddht.Create`. This PR fixes that