### PR TITLE
fix `did:dht` verification method ID handling

### DIFF
--- a/dids/diddht/internal/dns/did_test.go
+++ b/dids/diddht/internal/dns/did_test.go
@@ -2,7 +2,6 @@ package dns
 
 import (
 	"encoding/json"
-	"fmt"
 	"testing"
 
 	"github.com/alecthomas/assert/v2"
@@ -50,7 +49,6 @@ func Test_MarshalDIDDocument(t *testing.T) {
 	assert.NotZero(t, len(buf))
 
 	rec, _ := parseDNSDID(buf)
-	fmt.Println(rec)
 	reParsedDoc, err := rec.DIDDocument()
 	assert.NoError(t, err)
 	assert.NotZero(t, reParsedDoc)

--- a/dids/diddht/internal/dns/dns.go
+++ b/dids/diddht/internal/dns/dns.go
@@ -39,7 +39,7 @@ func (rec *decoder) DIDDocument() (*didcore.Document, error) {
 		switch {
 		case strings.HasPrefix(name, "_k"):
 			var vMethod didcore.VerificationMethod
-			if err := UnmarshalVerificationMethod(data, &vMethod); err != nil {
+			if err := UnmarshalVerificationMethod(data, document.ID, &vMethod); err != nil {
 				// TODO handle error
 				continue
 			}


### PR DESCRIPTION
# Summary
Included a short-term fix for a`did:dht` issue rasied here: https://github.com/TBD54566975/tbdex-go/pull/20#discussion_r1566623560


# Details

Fixed value resolution such that `vm.ID`s are always absolute. `main` wasn't accounting for the fact that `id` in a verification method TXT record is _only_ the fragment (excluding `'#'`) which was causing resolved did docs to look like this:
```json
{
  "id": "did:dht:9kkuh34q7nkd4tphbcg7py9h1g16iftbtskesi9courdwj96q3sy",
  "verificationMethod": [
    {
      "id": "0",
      "type": "JsonWebKey",
      "controller": "",
      "publicKeyJwk": {
        "kty": "OKP",
        "crv": "Ed25519",
        "x": "-pU-Z07olD1FvAsN1oP8kaXqliGNlItX7ITIOif-dmw"
      }
    }
  ],
  "assertionMethod": [
    "0"
  ],
  "authentication": [
    "0"
  ],
  "capabilityDelegation": [
    "0"
  ],
  "capabilityInvocation": [
    "0"
  ]
}
```

> [!WARNING]
> This PR doesn't accommodate for the fact that `id` can be omitted entirely and if so, should be set to the jwk thumbprint of the respective `PublicKeyJwk`. This will be addressed in a subsequent PR that does a broader refactor of `did:dht`
---

vm.Controller was not being set unless it was explicitly set in a verification method's TXT record. Per the spec, This PR sets `vm.Controller` to `document.ID` if it isn't explicitly set in the txt record

![image](https://github.com/TBD54566975/web5-go/assets/4887440/1fee440b-1967-44be-8809-9633f04288d9)


