### PR TITLE
`did:web` document Verification Method IDs

### DIFF
--- a/dids/didweb/didweb.go
+++ b/dids/didweb/didweb.go
@@ -167,7 +167,7 @@ func Create(domain string, opts ...CreateOption) (_did.BearerDID, error) {
 		}
 
 		vm := didcore.VerificationMethod{
-			ID:           "#" + strconv.Itoa(idx),
+			ID:           did.URI + "#" + strconv.Itoa(idx),
 			Type:         "JsonWebKey",
 			Controller:   did.URI,
 			PublicKeyJwk: &publicKeyJWK,

--- a/dids/didweb/didweb_test.go
+++ b/dids/didweb/didweb_test.go
@@ -50,6 +50,9 @@ func TestCreate_WithOptions(t *testing.T) {
 	assert.Equal(t, "did:example:123", document.AlsoKnownAs[0])
 	assert.Equal(t, "did:example:123", document.Controller[0])
 
+	assert.Equal(t, 1, len(document.VerificationMethod))
+	assert.Contains(t, document.VerificationMethod[0].ID, document.ID)
+
 }
 
 func TestTransformID(t *testing.T) {


### PR DESCRIPTION
on `main` `did:web` document Verification Method IDs are relative DID URLs e.g. `#0`. this PR ensures that VM IDs are absolute did URLs. Really want we need to do soon is update [`document.SelectVerificationMethod`](https://github.com/TBD54566975/web5-go/blob/didweb-document/dids/didcore/document.go#L130-L193) to handle both absolute and relative DID URLs. Decided to take the current approach to unblock myself