### PR TITLE
Setters and tests for VC evidence

### DIFF
--- a/vc/vc.go
+++ b/vc/vc.go
@@ -37,8 +37,8 @@ type DataModel[T CredentialSubject] struct {
 
 // Evidence represents the evidence property of a Verifiable Credential.
 type Evidence struct {
-	ID          string `json:"id,omitempty"`
-	Type        string `json:"type,omitempty"`
+	ID   string `json:"id,omitempty"`
+	Type string `json:"type,omitempty"`
 	// todo is `AdditionalFields` the right name?
 	AdditionalFields map[string]interface{}
 }
@@ -93,6 +93,7 @@ type createOptions struct {
 	issuanceDate   time.Time
 	expirationDate time.Time
 	schemas        []CredentialSchema
+	evidence       []Evidence
 }
 
 // CreateOption is the return type of all Option functions that can be passed to [Create]
@@ -157,6 +158,13 @@ func ExpirationDate(expirationDate time.Time) CreateOption {
 	}
 }
 
+// Evidences can be used to set the evidence array of the Verifiable Credential created by [Create]
+func Evidences(evidence ...Evidence) CreateOption {
+	return func(o *createOptions) {
+		o.evidence = evidence
+	}
+}
+
 // Create returns a new Verifiable Credential with the provided claims and options.
 // if no options are provided, the following defaults will be used:
 //   - ID: urn:vc:uuid:<uuid>
@@ -186,6 +194,7 @@ func Create[T CredentialSubject](claims T, opts ...CreateOption) DataModel[T] {
 		ID:                o.id,
 		IssuanceDate:      o.issuanceDate.UTC().Format(time.RFC3339),
 		CredentialSubject: claims,
+		Evidence:          o.evidence,
 	}
 
 	if len(o.schemas) > 0 {

--- a/vc/vc_test.go
+++ b/vc/vc_test.go
@@ -42,6 +42,14 @@ func TestCreate_Options(t *testing.T) {
 		vc.IssuanceDate(issuanceDate),
 		vc.ExpirationDate(expirationDate),
 		vc.Schemas("https://example.org/examples/degree.json"),
+		vc.Evidences(vc.Evidence{
+			ID:   "evidenceID",
+			Type: "Insufficient",
+			AdditionalFields: map[string]interface{}{
+				"kind":   "circumstantial",
+				"checks": []string{"motive", "cell_tower_logs"},
+			},
+		}),
 	)
 
 	assert.Equal(t, 2, len(cred.Context))
@@ -60,6 +68,11 @@ func TestCreate_Options(t *testing.T) {
 	assert.Equal(t, "https://example.org/examples/degree.json", cred.CredentialSchema[0].ID)
 	assert.Equal(t, "JsonSchema", cred.CredentialSchema[0].Type)
 
+	assert.Equal(t, 1, len(cred.Evidence))
+	assert.Equal(t, "evidenceID", cred.Evidence[0].ID)
+	assert.Equal(t, "Insufficient", cred.Evidence[0].Type)
+	assert.Equal(t, "circumstantial", cred.Evidence[0].AdditionalFields["kind"])
+	assert.Equal(t, []string{"motive", "cell_tower_logs"}, cred.Evidence[0].AdditionalFields["checks"].([]string)) // nolint:forcetypeassert
 }
 
 func TestSign(t *testing.T) {


### PR DESCRIPTION
Add code to let VC issuers supply evidence fields.

Continuation of #79 